### PR TITLE
Make constraint translatable

### DIFF
--- a/Form/Type/PhoneNumberType.php
+++ b/Form/Type/PhoneNumberType.php
@@ -55,7 +55,6 @@ class PhoneNumberType extends AbstractType
                 'compound' => false,
                 'default_region' => PhoneNumberUtil::UNKNOWN_REGION,
                 'format' => PhoneNumberFormat::INTERNATIONAL,
-                'invalid_message' => 'This is not a valid phone number.',
             )
         );
     }

--- a/Resources/translations/validators.en.xlf
+++ b/Resources/translations/validators.en.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>This value is not a valid phone number.</source>
+                <target>This value is not a valid phone number.</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>This value is not a valid mobile number.</source>
+                <target>This value is not a valid mobile number.</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>This value is not a valid fax number.</source>
+                <target>This value is not a valid fax number.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Tests/Validator/Constraints/PhoneNumberTest.php
+++ b/Tests/Validator/Constraints/PhoneNumberTest.php
@@ -29,4 +29,37 @@ class PhoneNumberTest extends TestCase
         $this->assertObjectHasAttribute('type', $phoneNumber);
         $this->assertObjectHasAttribute('defaultRegion', $phoneNumber);
     }
+
+    /**
+     * @dataProvider messageProvider
+     */
+    public function testMessage($message = null, $type = null, $expectedMessage)
+    {
+        $phoneNumber = new PhoneNumber();
+
+        if (null !== $message) {
+            $phoneNumber->message = $message;
+        }
+        if (null !== $type) {
+            $phoneNumber->type = $type;
+        }
+
+        $this->assertSame($expectedMessage, $phoneNumber->getMessage());
+    }
+
+    /**
+     * 0 => Message (optional)
+     * 1 => Type (optional)
+     * 2 => Expected message
+     */
+    public function messageProvider()
+    {
+        return array(
+            array(null, null, 'This value is not a valid phone number.'),
+            array(null, 'fax', 'This value is not a valid fax number.'),
+            array(null, 'mobile', 'This value is not a valid mobile number.'),
+            array('foo', null, 'foo'),
+            array('foo', 'mobile', 'foo'),
+        );
+    }
 }

--- a/Tests/Validator/Constraints/PhoneNumberValidatorTest.php
+++ b/Tests/Validator/Constraints/PhoneNumberValidatorTest.php
@@ -11,6 +11,8 @@
 
 namespace Misd\PhoneNumberBundle\Tests\Validator\Constraints;
 
+use libphonenumber\PhoneNumber as PhoneNumberObject;
+use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberUtil;
 use Misd\PhoneNumberBundle\Validator\Constraints\PhoneNumber;
 use Misd\PhoneNumberBundle\Validator\Constraints\PhoneNumberValidator;
@@ -33,17 +35,32 @@ class PhoneNumberValidatorTest extends TestCase
     /**
      * @dataProvider validateProvider
      */
-    public function testValidate($value, $violates, $defaultRegion = PhoneNumberUtil::UNKNOWN_REGION)
+    public function testValidate($value, $violates, $type = null, $defaultRegion = null)
     {
         $validator = new PhoneNumberValidator();
         $context = $this->getMock('Symfony\Component\Validator\ExecutionContextInterface');
         $validator->initialize($context);
 
         $constraint = new PhoneNumber();
-        $constraint->defaultRegion = $defaultRegion;
+        if (null !== $type) {
+            $constraint->type = $type;
+        }
+        if (null !== $defaultRegion) {
+            $constraint->defaultRegion = $defaultRegion;
+        }
 
         if (true === $violates) {
-            $context->expects($this->once())->method('addViolation');
+            if ($value instanceof PhoneNumberObject) {
+                $constraintValue = PhoneNumberUtil::getInstance()->format($value, PhoneNumberFormat::INTERNATIONAL);
+            } else {
+                $constraintValue = (string) $value;
+            }
+
+            $context->expects($this->once())->method('addViolation')
+                ->with(
+                    $constraint->getMessage(),
+                    array('{{ type }}' => $constraint->type, '{{ value }}' => $constraintValue)
+                );
         } else {
             $context->expects($this->never())->method('addViolation');
         }
@@ -54,7 +71,8 @@ class PhoneNumberValidatorTest extends TestCase
     /**
      * 0 => Value
      * 1 => Violates?
-     * 2 => Default region (optional)
+     * 2 => Type (optional)
+     * 3 => Default region (optional)
      */
     public function validateProvider()
     {
@@ -64,7 +82,8 @@ class PhoneNumberValidatorTest extends TestCase
             array(PhoneNumberUtil::getInstance()->parse('+441234567890', PhoneNumberUtil::UNKNOWN_REGION), false),
             array(PhoneNumberUtil::getInstance()->parse('+44123456789', PhoneNumberUtil::UNKNOWN_REGION), true),
             array('+441234567890', false),
-            array('01234 567890', false, 'GB'),
+            array('+44123456789', true, 'mobile'),
+            array('01234 567890', false, null, 'GB'),
             array('foo', true),
         );
     }

--- a/Validator/Constraints/PhoneNumber.php
+++ b/Validator/Constraints/PhoneNumber.php
@@ -23,7 +23,19 @@ use Symfony\Component\Validator\Constraint;
  */
 class PhoneNumber extends Constraint
 {
-    public $message = 'This value is not a valid {{ type }} number.';
+    private $defaultMessage = 'This value is not a valid phone number.';
+    private $typedMessage = 'This value is not a valid {{ type }} number.';
+
+    public $message = 'This value is not a valid phone number.';
     public $type = 'phone';
     public $defaultRegion = PhoneNumberUtil::UNKNOWN_REGION;
+
+    public function getMessage()
+    {
+        if ('phone' !== $this->type && $this->message === $this->defaultMessage) {
+            return strtr($this->typedMessage, array('{{ type }}' => $this->type));
+        }
+
+        return $this->message;
+    }
 }

--- a/Validator/Constraints/PhoneNumberValidator.php
+++ b/Validator/Constraints/PhoneNumberValidator.php
@@ -72,7 +72,7 @@ class PhoneNumberValidator extends ConstraintValidator
     private function addViolation($value, Constraint $constraint)
     {
         $this->context->addViolation(
-            $constraint->message,
+            $constraint->getMessage(),
             array('{{ type }}' => $constraint->type, '{{ value }}' => $value)
         );
     }


### PR DESCRIPTION
This is an attempt to make the constraint message translatable. I think have a 'type' was a bit of a mistake originally, but to maintain BC this should take care of it (allowing values of 'phone', 'fax' and 'mobile'). 
