### PR TITLE
Validate phone number type

### DIFF
--- a/Form/Type/PhoneNumberType.php
+++ b/Form/Type/PhoneNumberType.php
@@ -55,7 +55,7 @@ class PhoneNumberType extends AbstractType
                 'compound' => false,
                 'default_region' => PhoneNumberUtil::UNKNOWN_REGION,
                 'format' => PhoneNumberFormat::INTERNATIONAL,
-                'invalid_message' => 'This is not a valid phone number.',
+                'invalid_message' => 'This value is not a valid phone number.',
             )
         );
     }

--- a/README.md
+++ b/README.md
@@ -146,3 +146,10 @@ You can set the default region through the `defaultRegion` property:
      * @AssertPhoneNumber(defaultRegion="GB")
      */
     private $phoneNumber;
+
+By default any valid phone number will be accepted. You can restrict the type through the `type` property, recognised values are `mobile` and `fixed_line`. (Note the libphonenumber cannot always distinguish between mobile and fixed-line numbers (eg in the USA), in which case it will be accepted.)
+
+    /**
+     * @AssertPhoneNumber(type="mobile")
+     */
+    private $mobilePhoneNumber;

--- a/Resources/translations/validators.en.xlf
+++ b/Resources/translations/validators.en.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>This value is not a valid phone number.</source>
+                <target>This value is not a valid phone number.</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>This value is not a valid fixed-line number.</source>
+                <target>This value is not a valid fixed-line number.</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>This value is not a valid mobile number.</source>
+                <target>This value is not a valid mobile number.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/validators.en_CA.xlf
+++ b/Resources/translations/validators.en_CA.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="3">
+                <source>This value is not a valid mobile number.</source>
+                <target>This value is not a valid cell number.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/validators.en_PH.xlf
+++ b/Resources/translations/validators.en_PH.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="3">
+                <source>This value is not a valid mobile number.</source>
+                <target>This value is not a valid handphone number.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/validators.en_SG.xlf
+++ b/Resources/translations/validators.en_SG.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="3">
+                <source>This value is not a valid mobile number.</source>
+                <target>This value is not a valid handphone number.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/validators.en_US.xlf
+++ b/Resources/translations/validators.en_US.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="3">
+                <source>This value is not a valid mobile number.</source>
+                <target>This value is not a valid cell number.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/validators.en_ZA.xlf
+++ b/Resources/translations/validators.en_ZA.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="3">
+                <source>This value is not a valid mobile number.</source>
+                <target>This value is not a valid cell number.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Tests/Validator/Constraints/PhoneNumberTest.php
+++ b/Tests/Validator/Constraints/PhoneNumberTest.php
@@ -29,4 +29,38 @@ class PhoneNumberTest extends TestCase
         $this->assertObjectHasAttribute('type', $phoneNumber);
         $this->assertObjectHasAttribute('defaultRegion', $phoneNumber);
     }
+
+    /**
+     * @dataProvider messageProvider
+     */
+    public function testMessage($message = null, $type = null, $expectedMessage)
+    {
+        $phoneNumber = new PhoneNumber();
+
+        if (null !== $message) {
+            $phoneNumber->message = $message;
+        }
+        if (null !== $type) {
+            $phoneNumber->type = $type;
+        }
+
+        $this->assertSame($expectedMessage, $phoneNumber->getMessage());
+    }
+
+    /**
+     * 0 => Message (optional)
+     * 1 => Type (optional)
+     * 2 => Expected message
+     */
+    public function messageProvider()
+    {
+        return array(
+            array(null, null, 'This value is not a valid phone number.'),
+            array(null, 'fixed_line', 'This value is not a valid fixed-line number.'),
+            array(null, 'mobile', 'This value is not a valid mobile number.'),
+            array('foo', null, 'foo'),
+            array('foo', 'fixed_line', 'foo'),
+            array('foo', 'mobile', 'foo'),
+        );
+    }
 }

--- a/Tests/Validator/Constraints/PhoneNumberValidatorTest.php
+++ b/Tests/Validator/Constraints/PhoneNumberValidatorTest.php
@@ -11,6 +11,8 @@
 
 namespace Misd\PhoneNumberBundle\Tests\Validator\Constraints;
 
+use libphonenumber\PhoneNumber as PhoneNumberObject;
+use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberUtil;
 use Misd\PhoneNumberBundle\Validator\Constraints\PhoneNumber;
 use Misd\PhoneNumberBundle\Validator\Constraints\PhoneNumberValidator;
@@ -33,17 +35,32 @@ class PhoneNumberValidatorTest extends TestCase
     /**
      * @dataProvider validateProvider
      */
-    public function testValidate($value, $violates, $defaultRegion = PhoneNumberUtil::UNKNOWN_REGION)
+    public function testValidate($value, $violates, $type = null, $defaultRegion = null)
     {
         $validator = new PhoneNumberValidator();
         $context = $this->getMock('Symfony\Component\Validator\ExecutionContextInterface');
         $validator->initialize($context);
 
         $constraint = new PhoneNumber();
-        $constraint->defaultRegion = $defaultRegion;
+        if (null !== $type) {
+            $constraint->type = $type;
+        }
+        if (null !== $defaultRegion) {
+            $constraint->defaultRegion = $defaultRegion;
+        }
 
         if (true === $violates) {
-            $context->expects($this->once())->method('addViolation');
+            if ($value instanceof PhoneNumberObject) {
+                $constraintValue = PhoneNumberUtil::getInstance()->format($value, PhoneNumberFormat::INTERNATIONAL);
+            } else {
+                $constraintValue = (string) $value;
+            }
+
+            $context->expects($this->once())->method('addViolation')
+                ->with(
+                    $constraint->getMessage(),
+                    array('{{ type }}' => $constraint->type, '{{ value }}' => $constraintValue)
+                );
         } else {
             $context->expects($this->never())->method('addViolation');
         }
@@ -54,7 +71,8 @@ class PhoneNumberValidatorTest extends TestCase
     /**
      * 0 => Value
      * 1 => Violates?
-     * 2 => Default region (optional)
+     * 2 => Type (optional)
+     * 3 => Default region (optional)
      */
     public function validateProvider()
     {
@@ -62,9 +80,21 @@ class PhoneNumberValidatorTest extends TestCase
             array(null, false),
             array('', false),
             array(PhoneNumberUtil::getInstance()->parse('+441234567890', PhoneNumberUtil::UNKNOWN_REGION), false),
+            array(PhoneNumberUtil::getInstance()->parse('+441234567890', PhoneNumberUtil::UNKNOWN_REGION), false, 'fixed_line'),
+            array(PhoneNumberUtil::getInstance()->parse('+441234567890', PhoneNumberUtil::UNKNOWN_REGION), true, 'mobile'),
             array(PhoneNumberUtil::getInstance()->parse('+44123456789', PhoneNumberUtil::UNKNOWN_REGION), true),
             array('+441234567890', false),
-            array('01234 567890', false, 'GB'),
+            array('+441234567890', false, 'fixed_line'),
+            array('+441234567890', true, 'mobile'),
+            array('+44123456789', true),
+            array('+44123456789', true, 'mobile'),
+            array('+12015555555', false),
+            array('+12015555555', false, 'fixed_line'),
+            array('+12015555555', false, 'mobile'),
+            array('2015555555', false, null, 'US'),
+            array('2015555555', false, 'fixed_line', 'US'),
+            array('2015555555', false, 'mobile', 'US'),
+            array('01234 567890', false, null, 'GB'),
             array('foo', true),
         );
     }

--- a/Validator/Constraints/PhoneNumber.php
+++ b/Validator/Constraints/PhoneNumber.php
@@ -23,7 +23,42 @@ use Symfony\Component\Validator\Constraint;
  */
 class PhoneNumber extends Constraint
 {
-    public $message = 'This value is not a valid {{ type }} number.';
-    public $type = 'phone';
+    const ANY = 'any';
+    const FIXED_LINE = 'fixed_line';
+    const MOBILE = 'mobile';
+
+    private $anyMessage = 'This value is not a valid phone number.';
+    private $fixedLineMessage = 'This value is not a valid fixed-line number.';
+    private $mobileMessage = 'This value is not a valid mobile number.';
+
+    public $message = null;
+    public $type = self::ANY;
     public $defaultRegion = PhoneNumberUtil::UNKNOWN_REGION;
+
+    public function getType()
+    {
+        switch ($this->type) {
+            case self::FIXED_LINE:
+            case self::MOBILE:
+                return $this->type;
+        }
+
+        return self::ANY;
+    }
+
+    public function getMessage()
+    {
+        if (null !== $this->message) {
+            return $this->message;
+        }
+
+        switch ($this->type) {
+            case self::FIXED_LINE:
+                return $this->fixedLineMessage;
+            case self::MOBILE:
+                return $this->mobileMessage;
+        }
+
+        return $this->anyMessage;
+    }
 }

--- a/Validator/Constraints/PhoneNumberValidator.php
+++ b/Validator/Constraints/PhoneNumberValidator.php
@@ -14,6 +14,7 @@ namespace Misd\PhoneNumberBundle\Validator\Constraints;
 use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumber as PhoneNumberObject;
 use libphonenumber\PhoneNumberFormat;
+use libphonenumber\PhoneNumberType;
 use libphonenumber\PhoneNumberUtil;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -61,6 +62,29 @@ class PhoneNumberValidator extends ConstraintValidator
 
             return;
         }
+
+        switch ($constraint->getType()) {
+            case PhoneNumber::FIXED_LINE:
+                $validTypes = array(PhoneNumberType::FIXED_LINE, PhoneNumberType::FIXED_LINE_OR_MOBILE);
+                break;
+            case PhoneNumber::MOBILE:
+                $validTypes = array(PhoneNumberType::MOBILE, PhoneNumberType::FIXED_LINE_OR_MOBILE);
+                break;
+            default:
+                $validTypes = array();
+                break;
+        }
+
+        if (count($validTypes)) {
+            $type = $phoneUtil->getNumberType($phoneNumber);
+
+            if (false === in_array($type, $validTypes)) {
+                $this->addViolation($value, $constraint);
+
+                return;
+            }
+
+        }
     }
 
     /**
@@ -72,8 +96,8 @@ class PhoneNumberValidator extends ConstraintValidator
     private function addViolation($value, Constraint $constraint)
     {
         $this->context->addViolation(
-            $constraint->message,
-            array('{{ type }}' => $constraint->type, '{{ value }}' => $value)
+            $constraint->getMessage(),
+            array('{{ type }}' => $constraint->getType(), '{{ value }}' => $value)
         );
     }
 }


### PR DESCRIPTION
Second attempt at fixing #9 (replaces #12).

This makes the `type` property actually do something (valid values are `any`, `fixed_line` and `mobile`).

Three translatable messages are set (including the variations in English that I'm aware of).
