### PR TITLE
Throw exceptions in the Doctrine type

### DIFF
--- a/Doctrine/DBAL/Types/PhoneNumberType.php
+++ b/Doctrine/DBAL/Types/PhoneNumberType.php
@@ -12,7 +12,10 @@
 namespace Misd\PhoneNumberBundle\Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
+use libphonenumber\NumberParseException;
+use libphonenumber\PhoneNumber;
 use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberUtil;
 
@@ -51,6 +54,8 @@ class PhoneNumberType extends Type
     {
         if (null === $value) {
             return null;
+        } elseif (false === $value instanceof PhoneNumber) {
+            throw new ConversionException('Expected \libphonenumber\PhoneNumber, got ' . gettype($value));
         }
 
         $util = PhoneNumberUtil::getInstance();
@@ -69,7 +74,11 @@ class PhoneNumberType extends Type
 
         $util = PhoneNumberUtil::getInstance();
 
-        return $util->parse($value, PhoneNumberUtil::UNKNOWN_REGION);
+        try {
+            return $util->parse($value, PhoneNumberUtil::UNKNOWN_REGION);
+        } catch (NumberParseException $e) {
+            throw ConversionException::conversionFailed($value, self::NAME);
+        }
     }
 
     /**

--- a/Tests/Doctrine/DBAL/Types/PhoneNumberTypeTest.php
+++ b/Tests/Doctrine/DBAL/Types/PhoneNumberTypeTest.php
@@ -85,6 +85,14 @@ class PhoneNumberTypeTest extends TestCase
         $this->assertSame('+441234567890', $this->type->convertToDatabaseValue($phoneNumber, $this->platform));
     }
 
+    /**
+     * @expectedException \Doctrine\DBAL\Types\ConversionException
+     */
+    public function testConvertToDatabaseValueFailure()
+    {
+        $this->type->convertToDatabaseValue('foo', $this->platform);
+    }
+
     public function testConvertToPHPValueWithNull()
     {
         $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
@@ -96,6 +104,14 @@ class PhoneNumberTypeTest extends TestCase
 
         $this->assertInstanceOf('libphoneNumber\PhoneNumber', $phoneNumber);
         $this->assertSame('+441234567890', (string) $phoneNumber);
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\Types\ConversionException
+     */
+    public function testConvertToPHPValueFailure()
+    {
+        $this->type->convertToPHPValue('foo', $this->platform);
     }
 
     public function testRequiresSQLCommentHint()


### PR DESCRIPTION
Fixes #18 by throwing exceptions in the Doctrine type.

I've reused `ConversionException` in `convertToDatabaseValue()` as [others appear to be doing that](https://github.com/ramsey/uuid/blob/master/src/Doctrine/UuidType.php), though I have changed the message so that it makes sense.
