### PR TITLE
Add country choice form widget

### DIFF
--- a/DependencyInjection/Compiler/FormPhpTemplateCompilerPass.php
+++ b/DependencyInjection/Compiler/FormPhpTemplateCompilerPass.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony2 PhoneNumberBundle.
+ *
+ * (c) University of Cambridge
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Misd\PhoneNumberBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Form PHP template compiler pass.
+ *
+ * @author Chris Wilkinson <chris.wilkinson@admin.cam.ac.uk>
+ */
+class FormPhpTemplateCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (false === $container->hasParameter('templating.helper.form.resources')) {
+            return;
+        }
+
+        $parameter = $container->getParameter('templating.helper.form.resources');
+
+        if (in_array('MisdPhoneNumberBundle:Form', $parameter)) {
+            return;
+        }
+
+        // Insert right after FrameworkBundle:Form if exists.
+        if (($key = array_search('FrameworkBundle:Form', $parameter)) !== false) {
+            array_splice($parameter, ++$key, 0, array('MisdPhoneNumberBundle:Form'));
+        } else {
+            // Put it in first position.
+            array_unshift($resources, array('MisdPhoneNumberBundle:Form'));
+        }
+
+        $container->setParameter('templating.helper.form.resources', $parameter);
+    }
+}

--- a/DependencyInjection/Compiler/FormTwigTemplateCompilerPass.php
+++ b/DependencyInjection/Compiler/FormTwigTemplateCompilerPass.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony2 PhoneNumberBundle.
+ *
+ * (c) University of Cambridge
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Misd\PhoneNumberBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Form Twig template compiler pass.
+ *
+ * @author Chris Wilkinson <chris.wilkinson@admin.cam.ac.uk>
+ */
+class FormTwigTemplateCompilerPass implements CompilerPassInterface
+{
+    private $telLayout = 'MisdPhoneNumberBundle:Form:tel.html.twig';
+    private $telBootstrapLayout = 'MisdPhoneNumberBundle:Form:tel_bootstrap.html.twig';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (false === $container->hasParameter('twig.form.resources')) {
+            return;
+        }
+
+        $parameter = $container->getParameter('twig.form.resources');
+
+        if (in_array($this->telLayout, $parameter)) {
+            return;
+        }
+
+        // Insert right after base template if it exists.
+        if (($key = array_search('bootstrap_3_horizontal_layout.html.twig', $parameter)) !== false) {
+            array_splice($parameter, ++$key, 0, array($this->telBootstrapLayout));
+        } elseif (($key = array_search('bootstrap_3_layout.html.twig', $parameter)) !== false) {
+            array_splice($parameter, ++$key, 0, array($this->telBootstrapLayout));
+        } elseif (($key = array_search('form_div_layout.html.twig', $parameter)) !== false) {
+            array_splice($parameter, ++$key, 0, array($this->telLayout));
+        } else {
+            // Put it in first position.
+            array_unshift($parameter, array($this->telLayout));
+        }
+
+        $container->setParameter('twig.form.resources', $parameter);
+    }
+}

--- a/Form/DataTransformer/PhoneNumberToArrayTransformer.php
+++ b/Form/DataTransformer/PhoneNumberToArrayTransformer.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Symfony2 PhoneNumberBundle.
+ *
+ * (c) University of Cambridge
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Misd\PhoneNumberBundle\Form\DataTransformer;
+
+use libphonenumber\NumberParseException;
+use libphonenumber\PhoneNumber;
+use libphonenumber\PhoneNumberFormat;
+use libphonenumber\PhoneNumberUtil;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+/**
+ * Phone number to array transformer.
+ *
+ * @author Chris Wilkinson <chris.wilkinson@admin.cam.ac.uk>
+ */
+class PhoneNumberToArrayTransformer implements DataTransformerInterface
+{
+    /**
+     * @var array
+     */
+    private $countryChoices;
+
+    /**
+     * Constructor.
+     *
+     * @param array $countryChoices
+     */
+    public function __construct(array $countryChoices)
+    {
+        $this->countryChoices = $countryChoices;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($phoneNumber)
+    {
+        if (null === $phoneNumber) {
+            return array('country' => '', 'number' => '');
+        } elseif (false === $phoneNumber instanceof PhoneNumber) {
+            throw new TransformationFailedException('Expected a \libphonenumber\PhoneNumber.');
+        }
+
+        $util = PhoneNumberUtil::getInstance();
+
+        if (false === in_array($util->getRegionCodeForNumber($phoneNumber), $this->countryChoices)) {
+            throw new TransformationFailedException('Invalid country.');
+        }
+
+        return array(
+            'country' => $util->getRegionCodeForNumber($phoneNumber),
+            'number' => $util->format($phoneNumber, PhoneNumberFormat::NATIONAL),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reverseTransform($value)
+    {
+        if (!$value) {
+            return null;
+        }
+
+        if (!is_array($value)) {
+            throw new TransformationFailedException('Expected an array.');
+        }
+
+        if ('' === trim(implode('', $value))) {
+            return null;
+        }
+
+        $util = PhoneNumberUtil::getInstance();
+
+        try {
+            $phoneNumber = $util->parse($value['number'], $value['country']);
+        } catch (NumberParseException $e) {
+            throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
+        }
+
+        if (false === in_array($util->getRegionCodeForNumber($phoneNumber), $this->countryChoices)) {
+            throw new TransformationFailedException('Invalid country.');
+        }
+
+        return $phoneNumber;
+    }
+}

--- a/Form/Type/PhoneNumberType.php
+++ b/Form/Type/PhoneNumberType.php
@@ -13,11 +13,14 @@ namespace Misd\PhoneNumberBundle\Form\Type;
 
 use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberUtil;
+use Misd\PhoneNumberBundle\Form\DataTransformer\PhoneNumberToArrayTransformer;
 use Misd\PhoneNumberBundle\Form\DataTransformer\PhoneNumberToStringTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\Intl\Intl;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -28,14 +31,66 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  */
 class PhoneNumberType extends AbstractType
 {
+    const WIDGET_SINGLE_TEXT = 'single_text';
+    const WIDGET_COUNTRY_CHOICE = 'country_choice';
+
     /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->addViewTransformer(
-            new PhoneNumberToStringTransformer($options['default_region'], $options['format'])
-        );
+        if (self::WIDGET_COUNTRY_CHOICE === $options['widget']) {
+            $util = PhoneNumberUtil::getInstance();
+
+            $countries = array();
+
+            if (is_array($options['country_choices'])) {
+                foreach ($options['country_choices'] as $country) {
+                    $code = $util->getCountryCodeForRegion($country);
+
+                    if ($code) {
+                        $countries[$country] = $code;
+                    }
+                }
+            }
+
+            if (empty($countries)) {
+                foreach ($util->getSupportedRegions() as $country) {
+                    $countries[$country] = $util->getCountryCodeForRegion($country);
+                }
+            }
+
+            $countryChoices = array();
+
+            foreach (Intl::getRegionBundle()->getCountryNames() as $region => $name) {
+                if (false === isset($countries[$region])) {
+                    continue;
+                }
+
+                $countryChoices[$region] = sprintf('%s (+%s)', $name, $countries[$region]);
+            }
+
+            $countryOptions = $numberOptions = array(
+                'error_bubbling' => true,
+                'required' => $options['required'],
+                'disabled' => $options['disabled'],
+                'translation_domain' => $options['translation_domain'],
+            );
+
+            $countryOptions['required'] = true;
+            $countryOptions['choices'] = $countryChoices;
+            $countryOptions['preferred_choices'] = $options['preferred_country_choices'];
+            $countryOptions['choice_translation_domain'] = false;
+
+            $builder
+                ->add('country', 'choice', $countryOptions)
+                ->add('number', 'text', $numberOptions)
+                ->addViewTransformer(new PhoneNumberToArrayTransformer(array_keys($countryChoices)));
+        } else {
+            $builder->addViewTransformer(
+                new PhoneNumberToStringTransformer($options['default_region'], $options['format'])
+            );
+        }
     }
 
     /**
@@ -44,6 +99,7 @@ class PhoneNumberType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['type'] = 'tel';
+        $view->vars['widget'] = $options['widget'];
     }
 
     /**
@@ -64,12 +120,39 @@ class PhoneNumberType extends AbstractType
     {
         $resolver->setDefaults(
             array(
-                'compound' => false,
+                'widget' => self::WIDGET_SINGLE_TEXT,
+                'compound' => function (Options $options) {
+                    return PhoneNumberType::WIDGET_SINGLE_TEXT !== $options['widget'];
+                },
                 'default_region' => PhoneNumberUtil::UNKNOWN_REGION,
                 'format' => PhoneNumberFormat::INTERNATIONAL,
                 'invalid_message' => 'This value is not a valid phone number.',
+                'by_reference' => false,
+                'error_bubbling' => false,
+                'country_choices' => array(),
+                'preferred_country_choices' => array(),
             )
         );
+
+        if (method_exists($resolver, 'setDefault')) {
+            $resolver->setAllowedValues(
+                'widget',
+                array(
+                    self::WIDGET_SINGLE_TEXT,
+                    self::WIDGET_COUNTRY_CHOICE,
+                )
+            );
+        } else {
+            // To be removed when dependency on Symfony OptionsResolver is bumped to 2.6.
+            $resolver->setAllowedValues(
+                array(
+                    'widget' => array(
+                        self::WIDGET_SINGLE_TEXT,
+                        self::WIDGET_COUNTRY_CHOICE,
+                    ),
+                )
+            );
+        }
     }
 
     /**

--- a/MisdPhoneNumberBundle.php
+++ b/MisdPhoneNumberBundle.php
@@ -11,6 +11,8 @@
 
 namespace Misd\PhoneNumberBundle;
 
+use Misd\PhoneNumberBundle\DependencyInjection\Compiler\FormPhpTemplateCompilerPass;
+use Misd\PhoneNumberBundle\DependencyInjection\Compiler\FormTwigTemplateCompilerPass;
 use Misd\PhoneNumberBundle\DependencyInjection\Compiler\ParentLocalesCompilerPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -28,9 +30,13 @@ class MisdPhoneNumberBundle extends Bundle
      */
     public function build(ContainerBuilder $container)
     {
+        parent::build($container);
+
         $container->addCompilerPass(
           new ParentLocalesCompilerPass(),
           PassConfig::TYPE_BEFORE_REMOVING
         );
+        $container->addCompilerPass(new FormPhpTemplateCompilerPass());
+        $container->addCompilerPass(new FormTwigTemplateCompilerPass());
     }
 }

--- a/README.md
+++ b/README.md
@@ -127,7 +127,11 @@ Phone numbers can be deserialized from an international format by setting the ty
 
 ### Using `libphonenumber\PhoneNumber` objects in forms
 
-You can use the `tel` form type to create phone number fields. For example:
+You can use the `tel` form type to create phone number fields. There are two widgets available.
+
+#### Single text field
+
+A single text field allows the user to type in the complete phone number. When an international prefix is not entered, the number is assumed to be part of the set `default_region`. For example:
 
     use libphonenumber\PhoneNumberFormat;
     use Symfony\Component\Form\FormBuilderInterface;
@@ -138,6 +142,23 @@ You can use the `tel` form type to create phone number fields. For example:
     }
 
 By default the `default_region` and `format` options are `PhoneNumberUtil::UNKNOWN_REGION` and `PhoneNumberFormat::INTERNATIONAL` respectively.
+
+#### Country choice fields
+
+The phone number can be split into a country choice and phone number text fields. This allows the user to choose the relevant country (from a customisable list) and type in the phone number without international dialling.
+
+    use libphonenumber\PhoneNumberFormat;
+    use Misd\PhoneNumberBundle\Form\Type\PhoneNumberType;
+    use Symfony\Component\Form\FormBuilderInterface;
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('phone_number', 'tel', array('widget' => PhoneNumberType::WIDGET_COUNTRY_CHOICE, 'country_choices' => array('GB', 'JE', 'FR', 'US'), 'preferred_country_choices' => array('GB', 'JE')));
+    }
+
+This produces the preferred choices of 'Jersey' and 'United Kingdom', and regular choices of 'France' and 'United States'.
+
+By default the `country_choices` is empty, which means all countries are included, as is `preferred_country_choices`.
 
 ### Validating phone numbers
 

--- a/Resources/views/Form/tel.html.twig
+++ b/Resources/views/Form/tel.html.twig
@@ -1,0 +1,10 @@
+{% block tel_widget -%}
+    {% if widget is constant('Misd\\PhoneNumberBundle\\Form\\Type\\PhoneNumberType::WIDGET_COUNTRY_CHOICE') %}
+        <div {{ block('widget_container_attributes') }}>
+            {{- form_widget(form.country) -}}
+            {{- form_widget(form.number) -}}
+        </div>
+    {% else -%}
+        {{- block('form_widget_simple') -}}
+    {%- endif %}
+{%- endblock tel_widget %}

--- a/Resources/views/Form/tel_bootstrap.html.twig
+++ b/Resources/views/Form/tel_bootstrap.html.twig
@@ -1,0 +1,11 @@
+{% block tel_widget -%}
+    {% if widget is constant('Misd\\PhoneNumberBundle\\Form\\Type\\PhoneNumberType::WIDGET_COUNTRY_CHOICE') %}
+        {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) %}
+        <div {{ block('widget_container_attributes') }}>
+            {{- form_widget(form.country) -}}
+            {{- form_widget(form.number) -}}
+        </div>
+    {% else -%}
+        {{- block('form_widget_simple') -}}
+    {%- endif %}
+{%- endblock tel_widget %}

--- a/Resources/views/Form/tel_widget.html.php
+++ b/Resources/views/Form/tel_widget.html.php
@@ -1,0 +1,7 @@
+<?php if ($widget == Misd\PhoneNumberBundle\Form\Type\PhoneNumberType::WIDGET_COUNTRY_CHOICE): ?>
+    <div <?php echo $view['form']->block($form, 'widget_container_attributes') ?>>
+        <?php echo $view['form']->widget($form['country']).$view['form']->widget($form['number']); ?>
+    </div>
+<?php else: ?>
+    <?php echo $view['form']->block($form, 'form_widget_simple'); ?>
+<?php endif ?>

--- a/Tests/Form/DataTransformer/PhoneNumberToArrayTransformerTest.php
+++ b/Tests/Form/DataTransformer/PhoneNumberToArrayTransformerTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * This file is part of the Symfony2 PhoneNumberBundle.
+ *
+ * (c) University of Cambridge
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Misd\PhoneNumberBundle\Tests\Form\DataTransformer;
+
+use libphonenumber\NumberParseException;
+use libphonenumber\PhoneNumber;
+use libphonenumber\PhoneNumberUtil;
+use Misd\PhoneNumberBundle\Form\DataTransformer\PhoneNumberToArrayTransformer;
+use PHPUnit_Framework_TestCase as TestCase;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+/**
+ * Phone number to array transformer test.
+ *
+ * @author Chris Wilkinson <chris.wilkinson@admin.cam.ac.uk>
+ */
+class PhoneNumberToArrayTransformerTest extends TestCase
+{
+    const TRANSFORMATION_FAILED = 'transformation_failed';
+
+    public function testConstructor()
+    {
+        $transformer = new PhoneNumberToArrayTransformer(array());
+
+        $this->assertInstanceOf('Symfony\Component\Form\DataTransformerInterface', $transformer);
+    }
+
+    /**
+     * @dataProvider transformProvider
+     */
+    public function testTransform(array $countryChoices, $actual, $expected)
+    {
+        $transformer = new PhoneNumberToArrayTransformer($countryChoices);
+
+        $phoneNumberUtil = PhoneNumberUtil::getInstance();
+
+        if (is_array($actual)) {
+            try {
+                $phoneNumber = $phoneNumberUtil->parse($actual['number'], $actual['country']);
+            } catch (NumberParseException $e) {
+                $phoneNumber = $actual['number'];
+            }
+        } else {
+            $phoneNumber = $actual['number'];
+        }
+
+        try {
+            $transformed = $transformer->transform($phoneNumber);
+        } catch (TransformationFailedException $e) {
+            $transformed = self::TRANSFORMATION_FAILED;
+        }
+
+        $this->assertSame($expected, $transformed);
+    }
+
+    /**
+     * 0 => Country choices
+     * 1 => Actual value
+     * 2 => Expected result
+     */
+    public function transformProvider()
+    {
+        return array(
+            array(
+                array('GB'),
+                null,
+                array('country' => '', 'number' => ''),
+            ),
+            array(
+                array('GB'),
+                array('country' => 'GB', 'number' => '01234567890'),
+                array('country' => 'GB', 'number' => '01234 567890'),
+            ),
+            array(// Wrong country code, but matching country exists.
+                array('GB', 'JE'),
+                array('country' => 'JE', 'number' => '01234567890'),
+                array('country' => 'GB', 'number' => '01234 567890'),
+            ),
+            array(// Wrong country code, but matching country exists.
+                array('GB', 'JE'),
+                array('country' => 'JE', 'number' => '+441234567890'),
+                array('country' => 'GB', 'number' => '01234 567890'),
+            ),
+            array(// Country code not in list.
+                array('US'),
+                array('country' => 'GB', 'number' => '01234567890'),
+                self::TRANSFORMATION_FAILED,
+            ),
+            array(
+                array('US'),
+                array('country' => 'GB', 'number' => 'foo'),
+                self::TRANSFORMATION_FAILED,
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider reverseTransformProvider
+     */
+    public function testReverseTransform(array $countryChoices, $actual, $expected)
+    {
+        $transformer = new PhoneNumberToArrayTransformer($countryChoices);
+
+        try {
+            $transformed = $transformer->reverseTransform($actual);
+        } catch (TransformationFailedException $e) {
+            $transformed = self::TRANSFORMATION_FAILED;
+        }
+
+        if ($transformed instanceof PhoneNumber) {
+            $transformed = (string) $transformed;
+        }
+
+        $this->assertSame($expected, $transformed);
+    }
+
+    /**
+     * 0 => Country choices
+     * 1 => Actual value
+     * 2 => Expected result
+     */
+    public function reverseTransformProvider()
+    {
+        return array(
+            array(
+                array('GB'),
+                null,
+                null,
+            ),
+            array(
+                array('GB'),
+                'foo',
+                self::TRANSFORMATION_FAILED,
+            ),
+            array(
+                array('GB'),
+                array('country' => '', 'number' => ''),
+                null,
+            ),
+            array(
+                array('GB'),
+                array('country' => '', 'number' => 'foo'),
+                self::TRANSFORMATION_FAILED,
+            ),
+            array(
+                array('GB'),
+                array('country' => 'GB', 'number' => '01234 567890'),
+                '+441234567890',
+            ),
+            array(
+                array('GB'),
+                array('country' => 'GB', 'number' => '+44 1234 567890'),
+                '+441234567890',
+            ),
+            array(// Country code not in list.
+                array('US'),
+                array('country' => 'GB', 'number' => '+44 1234 567890'),
+                self::TRANSFORMATION_FAILED,
+            ),
+        );
+    }
+}

--- a/Tests/Form/Type/PhoneNumberTypeTest.php
+++ b/Tests/Form/Type/PhoneNumberTypeTest.php
@@ -12,8 +12,11 @@
 namespace Misd\PhoneNumberBundle\Tests\Form\Type;
 
 use libphonenumber\PhoneNumberFormat;
+use libphonenumber\PhoneNumberUtil;
+use Locale;
 use Misd\PhoneNumberBundle\Form\Type\PhoneNumberType;
 use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Intl\Util\IntlTestHelper;
 
 /**
  * Phone number form type test.
@@ -22,10 +25,17 @@ use Symfony\Component\Form\Test\TypeTestCase;
  */
 class PhoneNumberTypeTest extends TypeTestCase
 {
+    protected function setUp()
+    {
+        IntlTestHelper::requireIntl($this);
+
+        parent::setUp();
+    }
+
     /**
-     * @dataProvider defaultFormattingProvider
+     * @dataProvider singleFieldProvider
      */
-    public function testDefaultFormatting($input, $options, $output)
+    public function testSingleField($input, $options, $output)
     {
         $type = new PhoneNumberType();
         $form = $this->factory->create($type, null, $options);
@@ -40,7 +50,12 @@ class PhoneNumberTypeTest extends TypeTestCase
         $this->assertSame($output, $view->vars['value']);
     }
 
-    public function defaultFormattingProvider()
+    /**
+     * 0 => Input
+     * 1 => Options
+     * 2 => Output
+     */
+    public function singleFieldProvider()
     {
         return array(
             array('+441234567890', array(), '+44 1234 567890'),
@@ -50,5 +65,122 @@ class PhoneNumberTypeTest extends TypeTestCase
             array('01234 567890', array('default_region' => 'GB'), '+44 1234 567890'),
             array('', array(), ''),
         );
+    }
+
+    /**
+     * @dataProvider countryChoiceValuesProvider
+     */
+    public function testCountryChoiceValues($input, $options, $output)
+    {
+        $options['widget'] = PhoneNumberType::WIDGET_COUNTRY_CHOICE;
+        $form = $this->factory->create(new PhoneNumberType(), null, $options);
+
+        $form->submit($input);
+
+        $this->assertTrue($form->isSynchronized());
+
+        $view = $form->createView();
+
+        $this->assertSame('tel', $view->vars['type']);
+        $this->assertSame($output, $view->vars['value']);
+    }
+
+    /**
+     * 0 => Input
+     * 1 => Options
+     * 2 => Output
+     */
+    public function countryChoiceValuesProvider()
+    {
+        return array(
+            array(array('country' => 'GB', 'number' => '01234 567890'), array(), array('country' => 'GB', 'number' => '01234 567890')),
+            array(array('country' => 'GB', 'number' => '+44 1234 567890'), array(), array('country' => 'GB', 'number' => '01234 567890')),
+            array(array('country' => 'GB', 'number' => '1234 567890'), array(), array('country' => 'GB', 'number' => '01234 567890')),
+            array(array('country' => 'GB', 'number' => '+1 650-253-0000'), array(), array('country' => 'US', 'number' => '(650) 253-0000')),
+            array(array('country' => '', 'number' => ''), array(), array('country' => '', 'number' => '')),
+        );
+    }
+
+    /**
+     * @dataProvider countryChoiceChoicesProvider
+     */
+    public function testCountryChoiceChoices(array $choices, $expectedChoicesCount, array $expectedChoices)
+    {
+        $form = $this->factory->create(new PhoneNumberType(), null, array('widget' => PhoneNumberType::WIDGET_COUNTRY_CHOICE, 'country_choices' => $choices));
+
+        $view = $form->createView();
+        $choices = $view['country']->vars['choices'];
+
+        $this->assertCount($expectedChoicesCount, $choices);
+        foreach ($expectedChoices as $expectedChoice) {
+            $this->assertContains($expectedChoice, $choices, '', false, false);
+        }
+    }
+
+    /**
+     * 0 => Choices
+     * 1 => Expected choices count
+     * 2 => Expected choices
+     */
+    public function countryChoiceChoicesProvider()
+    {
+        return array(
+            array(
+                array(),
+                count(PhoneNumberUtil::getInstance()->getSupportedRegions()),
+                array(
+                    $this->createChoiceView('United Kingdom (+44)', 'GB', 'GB'),
+                ),
+            ),
+            array(
+                array('GB', 'US'),
+                2,
+                array(
+                    $this->createChoiceView('United Kingdom (+44)', 'GB', 'GB'),
+                    $this->createChoiceView('United States (+1)', 'US', 'US'),
+                ),
+            ),
+            array(
+                array('GB', 'US', PhoneNumberUtil::UNKNOWN_REGION),
+                2,
+                array(
+                    $this->createChoiceView('United Kingdom (+44)', 'GB', 'GB'),
+                    $this->createChoiceView('United States (+1)', 'US', 'US'),
+                ),
+            ),
+        );
+    }
+
+    public function testCountryChoiceTranslations()
+    {
+        IntlTestHelper::requireFullIntl($this);
+        Locale::setDefault('fr');
+
+        $form = $this->factory->create(new PhoneNumberType(), null, array('widget' => PhoneNumberType::WIDGET_COUNTRY_CHOICE));
+
+        $view = $form->createView();
+        $choices = $view['country']->vars['choices'];
+
+        $this->assertContains($this->createChoiceView('Royaume-Uni (+44)', 'GB', 'GB'), $choices, '', false, false);
+        $this->assertFalse($view['country']->vars['choice_translation_domain']);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testInvalidWidget()
+    {
+        $this->factory->create(new PhoneNumberType(), null, array('widget' => 'foo'));
+    }
+
+    private function createChoiceView($data, $value, $label)
+    {
+        if (class_exists('Symfony\Component\Form\ChoiceList\View\ChoiceView')) {
+            $class = 'Symfony\Component\Form\ChoiceList\View\ChoiceView';
+        } else {
+            $class = 'Symfony\Component\Form\Extension\Core\View\ChoiceView';
+        }
+
+        return new $class($data, $value, $label);
     }
 }


### PR DESCRIPTION
This is a first stab at adding a different form widget, split into number and country choice (refs #19).

![image](https://cloud.githubusercontent.com/assets/1784740/4875973/cfc6f530-62af-11e4-8687-5080a1559bea.png)

The country choice is customisable (loads all from libphonenumber by default), and is translated. Loading a large list is rather memory intensive (the whole list is about 3MB), so it might be better to cache this data when the container is compiled.

The sorting of the list isn't ideal, as it relies on `Intl::getRegionBundle()->getCountryNames()` for the ordering.

- [x] Add tests
- [ ] Look into caching valid region codes
- [ ] Look into ordering improvements.
- [x] Make sure it looks ok with the Bootstrap form them introduced in Symfony 2.6.
- [x] Make country choice 'required'.