### PR TITLE
Add libphonenumber-for-php v7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 
 env:
   - SYMFONY_VERSION="2.1.0" LIBPHONENUMBER_VERSION="~5.7"
-  - SYMFONY_VERSION="~2.1" LIBPHONENUMBER_VERSION="~6.0"
+  - SYMFONY_VERSION="~2.1" LIBPHONENUMBER_VERSION="~7.0"
 
 before_install:
   - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "giggsey/libphonenumber-for-php": "~5.7|~6.0",
+        "giggsey/libphonenumber-for-php": "~5.7|~6.0|~7.0",
         "symfony/framework-bundle": "~2.1"
     },
     "require-dev": {


### PR DESCRIPTION
Google have released v7 with no major incompatible changes (they deprecated some functions, but have not removed them yet).
