### PR TITLE
Use ICU locale inheritance rules

### DIFF
--- a/DependencyInjection/Compiler/ParentLocalesCompilerPass.php
+++ b/DependencyInjection/Compiler/ParentLocalesCompilerPass.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Symfony2 PhoneNumberBundle.
+ *
+ * (c) University of Cambridge
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Misd\PhoneNumberBundle\DependencyInjection\Compiler;
+
+use InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Parent locales compiler pass.
+ *
+ * Symfony isn't aware of the ICU locale inheritance rules, so to save having
+ * to have lots of duplicated translations we add them in here.
+ *
+ * See https://github.com/symfony/symfony/issues/12319 for further details.
+ *
+ * @author Chris Wilkinson <chris.wilkinson@admin.cam.ac.uk>
+ */
+class ParentLocalesCompilerPass implements CompilerPassInterface
+{
+    /**
+     * Locale => parent locale map (as defined in ICU).
+     *
+     * @var array
+     */
+    private $localParents = array(
+      'es_AR' => 'es_419',
+      'es_BO' => 'es_419',
+      'es_CL' => 'es_419',
+      'es_CO' => 'es_419',
+      'es_CR' => 'es_419',
+      'es_CU' => 'es_419',
+      'es_DO' => 'es_419',
+      'es_EC' => 'es_419',
+      'es_GT' => 'es_419',
+      'es_HN' => 'es_419',
+      'es_MX' => 'es_419',
+      'es_NI' => 'es_419',
+      'es_PA' => 'es_419',
+      'es_PE' => 'es_419',
+      'es_PR' => 'es_419',
+      'es_PY' => 'es_419',
+      'es_SV' => 'es_419',
+      'es_US' => 'es_419',
+      'es_UY' => 'es_419',
+      'es_VE' => 'es_419',
+    );
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        try {
+            $translator = $container->findDefinition('translator');
+        } catch (InvalidArgumentException $e) {
+            return;
+        }
+
+        if (
+          'Symfony\Component\Translation\Translator' !== $translator->getClass()
+          &&
+          false === is_subclass_of($translator->getClass(), 'Symfony\Component\Translation\Translator')
+        ) {
+            return;
+        }
+
+        $methodCalls = array_values($translator->getMethodCalls());
+
+        foreach ($this->localParents as $locale => $parent) {
+            $path = realpath(
+              sprintf(
+                '%s/../../Resources/translations/validators.%s.xlf',
+                __DIR__,
+                $parent
+              )
+            );
+
+            if (false === $path) {
+                continue;
+            }
+
+            $parentKey = null;
+
+            // Find the position of the parent locale addResource() call so that
+            // we can insert the child locale's call directly after rather than
+            // just appending it. This means that the user can then still
+            // override the translation.
+            foreach ($methodCalls as $i => $methodCall) {
+                if (
+                  'addResource' === $methodCall[0]
+                  &&
+                  $path === realpath($methodCall[1][1])
+                ) {
+                    $parentKey = $i;
+                    break;
+                }
+            }
+
+            $extraMethodCall = array(
+              'addResource',
+              array(
+                'xlf',
+                $path,
+                $locale,
+                'validators',
+              ),
+            );
+
+            if (null === $parentKey) {
+                $methodCalls[] = $extraMethodCall;
+            } else {
+                array_splice(
+                  $methodCalls,
+                  $parentKey + 1,
+                  0,
+                  array($extraMethodCall)
+                );
+            }
+        }
+
+        $translator->setMethodCalls($methodCalls);
+    }
+}

--- a/MisdPhoneNumberBundle.php
+++ b/MisdPhoneNumberBundle.php
@@ -11,6 +11,9 @@
 
 namespace Misd\PhoneNumberBundle;
 
+use Misd\PhoneNumberBundle\DependencyInjection\Compiler\ParentLocalesCompilerPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -20,4 +23,14 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class MisdPhoneNumberBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(
+          new ParentLocalesCompilerPass(),
+          PassConfig::TYPE_BEFORE_REMOVING
+        );
+    }
 }

--- a/Tests/DependencyInjection/Compiler/ParentLocalesCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ParentLocalesCompilerPassTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony2 PhoneNumberBundle.
+ *
+ * (c) University of Cambridge
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Misd\PhoneNumberBundle\Tests\DependencyInjection\Compiler;
+
+use Misd\PhoneNumberBundle\DependencyInjection\Compiler\ParentLocalesCompilerPass;
+use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionClass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * Parent locales compiler pass test.
+ *
+ * @author Chris Wilkinson <chris.wilkinson@admin.cam.ac.uk>
+ */
+class ParentLocalesCompilerPassTest extends TestCase
+{
+    public function testNoTranslator()
+    {
+        $compilerPass = new ParentLocalesCompilerPass();
+
+        $container = new ContainerBuilder();
+
+        $compilerPass->process($container);
+    }
+
+    public function testDifferentTranslator()
+    {
+        $compilerPass = new ParentLocalesCompilerPass();
+
+        $container = new ContainerBuilder();
+
+        $translatorDefinition = new Definition(
+          'Symfony\Component\Translation\IdentityTranslator'
+        );
+
+        $container->setDefinition('translator', $translatorDefinition);
+
+        $compilerPass->process($container);
+
+        $this->assertEmpty($translatorDefinition->getMethodCalls());
+    }
+
+    public function testTranslator()
+    {
+        $compilerPass = new ParentLocalesCompilerPass();
+
+        $container = new ContainerBuilder();
+
+        $translatorDefinition = new Definition(
+          'Symfony\Component\Translation\Translator'
+        );
+
+        $container->setDefinition('translator', $translatorDefinition);
+
+        $compilerPass->process($container);
+
+        $this->assertCount(
+          count($this->getLocalParents($compilerPass)),
+          $translatorDefinition->getMethodCalls()
+        );
+    }
+
+    private function getLocalParents(ParentLocalesCompilerPass $compilerPass)
+    {
+        $reflectionClass = new ReflectionClass('Misd\PhoneNumberBundle\DependencyInjection\Compiler\ParentLocalesCompilerPass');
+        $reflectionProperty = $reflectionClass->getProperty('localParents');
+        $reflectionProperty->setAccessible(true);
+
+        return $reflectionProperty->getValue($compilerPass);
+    }
+}


### PR DESCRIPTION
#22 added Spanish translations, but to use `es_419` we need to manually load it and set it to appear as the various child locales (`es_AR`, `es_BO` etc).