### PR TITLE
Test using lowest possible dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3.3
   - 5.3
   - 5.4
   - 5.5
@@ -11,16 +10,11 @@ php:
 matrix:
     allow_failures:
         - php: hhvm
-
-env:
-  - SYMFONY_VERSION="2.1.0" LIBPHONENUMBER_VERSION="~5.7"
-  - SYMFONY_VERSION="~2.1" LIBPHONENUMBER_VERSION="~7.0"
-
-before_install:
-  - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update --no-interaction
-  - composer require giggsey/libphonenumber-for-php:${LIBPHONENUMBER_VERSION} --no-update --no-interaction
+    include:
+        - php: 5.3.3
+          env: dependencies=lowest
 
 install:
-  - composer install --dev --prefer-source --no-interaction
+  - if [ "$dependencies" = "lowest" ]; then composer update --dev --prefer-lowest --prefer-stable --prefer-source --no-interaction; else composer install --dev --prefer-source --no-interaction; fi;
 
 script: ./vendor/bin/phpunit --coverage-text

--- a/Tests/Validator/Constraints/PhoneNumberValidatorTest.php
+++ b/Tests/Validator/Constraints/PhoneNumberValidatorTest.php
@@ -38,7 +38,8 @@ class PhoneNumberValidatorTest extends TestCase
     public function testValidate($value, $violates, $type = null, $defaultRegion = null)
     {
         $validator = new PhoneNumberValidator();
-        $context = $this->getMock('Symfony\Component\Validator\ExecutionContextInterface');
+        $context = $this->getMockBuilder('Symfony\Component\Validator\ExecutionContext')
+          ->disableOriginalConstructor()->getMock();
         $validator->initialize($context);
 
         $constraint = new PhoneNumber();

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
         "symfony/twig-bundle": "~2.1",
         "symfony/validator": "~2.1"
     },
+    "conflict": {
+        "twig/twig": "<1.12.0"
+    },
     "suggest": {
         "doctrine/doctrine-bundle": "Add a DBAL mapping type",
         "jms/serializer-bundle": "Serialize/deserialize phone numbers",


### PR DESCRIPTION
This is an attempt to use Composer's new `--prefer-lowest` to make sure that the dependency constraints are valid.