### PR TITLE
Doctrine convert made easier

### DIFF
--- a/Doctrine/DBAL/Types/PhoneNumberType.php
+++ b/Doctrine/DBAL/Types/PhoneNumberType.php
@@ -54,7 +54,9 @@ class PhoneNumberType extends Type
     {
         if (null === $value) {
             return null;
-        } elseif (false === $value instanceof PhoneNumber) {
+        }
+
+        if (!$value instanceof PhoneNumber) {
             throw new ConversionException('Expected \libphonenumber\PhoneNumber, got ' . gettype($value));
         }
 
@@ -68,8 +70,8 @@ class PhoneNumberType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if (null === $value) {
-            return null;
+        if (null === $value || $value instanceof PhoneNumber) {
+            return $value;
         }
 
         $util = PhoneNumberUtil::getInstance();

--- a/Tests/Doctrine/DBAL/Types/PhoneNumberTypeTest.php
+++ b/Tests/Doctrine/DBAL/Types/PhoneNumberTypeTest.php
@@ -106,6 +106,15 @@ class PhoneNumberTypeTest extends TestCase
         $this->assertSame('+441234567890', (string) $phoneNumber);
     }
 
+    public function testConvertToPHPValueWithAPhoneNumberInstance()
+    {
+        $expectedPhoneNumber = $this->phoneNumberUtil->parse('+441234567890', PhoneNumberUtil::UNKNOWN_REGION);
+
+        $phoneNumber = $this->type->convertToPHPValue($expectedPhoneNumber, $this->platform);
+
+        $this->assertEquals($expectedPhoneNumber, $phoneNumber);
+    }
+
     /**
      * @expectedException \Doctrine\DBAL\Types\ConversionException
      */


### PR DESCRIPTION
Make the doctrine type handle valid PhoneNumber strings when converting to a database value and make the PHP conversion allow for a PhoneNumber instance.