### PR TITLE
 Deprecated:  The Definition::setFactoryService method is deprecated since version 2.6...

### DIFF
--- a/DependencyInjection/MisdPhoneNumberExtension.php
+++ b/DependencyInjection/MisdPhoneNumberExtension.php
@@ -13,8 +13,10 @@ namespace Misd\PhoneNumberBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
 
 /**
  * Bundle extension.
@@ -30,5 +32,31 @@ class MisdPhoneNumberExtension extends Extension
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
+
+        $this->setFactory($container->getDefinition('libphonenumber.phone_number_util'));
+        $this->setFactory($container->getDefinition('libphonenumber.phone_number_offline_geocoder'));
+        $this->setFactory($container->getDefinition('libphonenumber.short_number_info'));
+        $this->setFactory($container->getDefinition('libphonenumber.phone_number_to_carrier_mapper'));
+        $this->setFactory($container->getDefinition('libphonenumber.phone_number_to_time_zones_mapper'));
+    }
+
+    /**
+     * Set Factory of FactoryClass & FactoryMethod based on Symfony version.
+     *
+     * to be removed when dependency on Symfony DependencyInjection is bumped to 2.6 and
+     * services inlined in services.xml
+     *
+     * @param $def
+     */
+    private function setFactory(Definition $def)
+    {
+        if (method_exists($def, 'setFactory')) {
+            // to be inlined in services.xml when dependency on Symfony DependencyInjection is bumped to 2.6
+            $def->setFactory(array($def->getClass(), 'getInstance'));
+        } else {
+            // to be removed when dependency on Symfony DependencyInjection is bumped to 2.6
+            $def->setFactoryClass($def->getClass());
+            $def->setFactoryMethod('getInstance');
+        }
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -18,20 +18,18 @@
 
     <services>
 
-        <service id="libphonenumber.phone_number_util" class="%libphonenumber.phone_number_util.class%"
-                 factory-class="%libphonenumber.phone_number_util.class%" factory-method="getInstance"/>
+        <service id="libphonenumber.phone_number_util" class="%libphonenumber.phone_number_util.class%"/>
 
-        <service id="libphonenumber.phone_number_offline_geocoder" class="%libphonenumber.phone_number_offline_geocoder.class%"
-                 factory-class="%libphonenumber.phone_number_offline_geocoder.class%" factory-method="getInstance"/>
+        <service id="libphonenumber.phone_number_offline_geocoder"
+                 class="%libphonenumber.phone_number_offline_geocoder.class%"/>
 
-        <service id="libphonenumber.short_number_info" class="%libphonenumber.short_number_info.class%"
-                 factory-class="%libphonenumber.short_number_info.class%" factory-method="getInstance"/>
+        <service id="libphonenumber.short_number_info" class="%libphonenumber.short_number_info.class%"/>
 
-        <service id="libphonenumber.phone_number_to_carrier_mapper" class="%libphonenumber.phone_number_to_carrier_mapper.class%"
-                 factory-class="%libphonenumber.phone_number_to_carrier_mapper.class%" factory-method="getInstance"/>
+        <service id="libphonenumber.phone_number_to_carrier_mapper"
+                 class="%libphonenumber.phone_number_to_carrier_mapper.class%"/>
 
-        <service id="libphonenumber.phone_number_to_time_zones_mapper" class="%libphonenumber.phone_number_to_time_zones_mapper.class%"
-                 factory-class="%libphonenumber.phone_number_to_time_zones_mapper.class%" factory-method="getInstance"/>
+        <service id="libphonenumber.phone_number_to_time_zones_mapper"
+                 class="%libphonenumber.phone_number_to_time_zones_mapper.class%"/>
 
         <service id="misd_phone_number.templating.helper.format"
                  class="%misd_phone_number.templating.helper.format.class%">


### PR DESCRIPTION
... and will be removed in 3.0. Use Definition::setFactory() instead.

I was getting spammed by notices, so decided to fix it.

Note: that this will break BC when you are using symfony below version 2.6. (then again people should update)