### PR TITLE
Cater for Symfony Form/Validator deprecations

### DIFF
--- a/Form/Type/PhoneNumberType.php
+++ b/Form/Type/PhoneNumberType.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -47,8 +48,19 @@ class PhoneNumberType extends AbstractType
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated To be removed when the Symfony Form component compatibility
+     *             is bumped to at least 2.7.
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(

--- a/Tests/Form/Type/PhoneNumberTypeTest.php
+++ b/Tests/Form/Type/PhoneNumberTypeTest.php
@@ -13,7 +13,7 @@ namespace Misd\PhoneNumberBundle\Tests\Form\Type;
 
 use libphonenumber\PhoneNumberFormat;
 use Misd\PhoneNumberBundle\Form\Type\PhoneNumberType;
-use Symfony\Component\Form\Tests\Extension\Core\Type\TypeTestCase;
+use Symfony\Component\Form\Test\TypeTestCase;
 
 /**
  * Phone number form type test.
@@ -30,7 +30,7 @@ class PhoneNumberTypeTest extends TypeTestCase
         $type = new PhoneNumberType();
         $form = $this->factory->create($type, null, $options);
 
-        $form->bind($input);
+        $form->submit($input);
 
         $this->assertTrue($form->isSynchronized());
 

--- a/Tests/Validator/Constraints/PhoneNumberValidatorTest.php
+++ b/Tests/Validator/Constraints/PhoneNumberValidatorTest.php
@@ -36,7 +36,12 @@ class PhoneNumberValidatorTest extends TestCase
     public function testValidate($value, $violates, $defaultRegion = PhoneNumberUtil::UNKNOWN_REGION)
     {
         $validator = new PhoneNumberValidator();
-        $context = $this->getMockBuilder('Symfony\Component\Validator\ExecutionContext')
+        if (class_exists('Symfony\Component\Validator\Context\ExecutionContext')) {
+            $executionContextClass = 'Symfony\Component\Validator\Context\ExecutionContext';
+        } else {
+            $executionContextClass = 'Symfony\Component\Validator\ExecutionContext';
+        }
+        $context = $this->getMockBuilder($executionContextClass)
           ->disableOriginalConstructor()->getMock();
         $validator->initialize($context);
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "doctrine/doctrine-bundle": "~1.0",
         "jms/serializer-bundle": "~0.11",
         "phpunit/phpunit": "~4.0",
-        "symfony/form": "~2.1",
+        "symfony/form": "~2.3",
         "symfony/templating": "~2.1",
         "symfony/twig-bundle": "~2.1",
         "symfony/validator": "~2.1"


### PR DESCRIPTION
Combined with #47 this will stop Symfony's depreciation warnings when using 2.7 (unless any more are added).

I had to bump the Form dev requirement due to the `TypeTestCase` move.

Note that this does mean that custom implementations of `OptionsResolverInterface` will break, but as Symfony itself does this it can be considered safe (see https://github.com/symfony/symfony/pull/12891).