### PR TITLE
Add nightly PHP to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - nightly
   - hhvm
 
 matrix:
     allow_failures:
-        - php: hhvm
+        - php: nightly
     include:
         - php: 5.3.3
           env: dependencies=lowest


### PR DESCRIPTION
This also adds nightly HHVM, and marks HHVM as required.