### PR TITLE
added PhoneNumberType check for twig

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ This creates a `varchar(35)` column with a Doctrine mapping comment.
 
 Note that if you're putting the `phone_number` type on an already-existing schema the current values must be converted to the `libphonenumber\PhoneNumberFormat::E164` format.
 
-### Formatting `libphonenumber\PhoneNumber` objects
+### Templating
 
 #### Twig
 
+##### phone_number_format
 The `phone_number_format` filter can be used to format a phone number object. A `libphonenumber\PhoneNumberFormat` constant can be passed as argument to specify in which format the number should be printed.
 
 For example, to format an object called `myPhoneNumber` in the `libphonenumber\PhoneNumberFormat::NATIONAL` format:
@@ -83,19 +84,45 @@ For example, to format an object called `myPhoneNumber` in the `libphonenumber\P
 
 By default phone numbers are formatted in the `libphonenumber\PhoneNumberFormat::INTERNATIONAL` format.
 
+###### phone_number_is_type
+
+The `phone_number_is_type` function takes two arguments: a `libphonenumber\PhoneNumber` object and an optional `libphonenumber\PhoneNumberType` constant name.
+
+For example, to check if an object called `myPhoneNumber` is a `libphonenumber\PhoneNumberType::MOBILE` type:
+
+    {% if phone_number_is_type(myPhoneNumber, 'MOBILE') }} %} ... {% endif %}
+
 #### PHP template
 
-The `format()` method in the `phone_number_format` helper takes two arguments: a `libphonenumber\PhoneNumber` object and an optional `libphonenumber\PhoneNumberFormat` constant name or value.
+##### format()
+
+The `format()` method in the `phone_number_helper` takes two arguments: a `libphonenumber\PhoneNumber` object and an optional `libphonenumber\PhoneNumberFormat` constant name or value.
 
 For example, to format `$myPhoneNumber` in the `libphonenumber\PhoneNumberFormat::NATIONAL` format, either use:
 
-    <?php echo $view['phone_number_format']->format($myPhoneNumber, 'NATIONAL') ?>
+    <?php echo $view['phone_number_helper']->format($myPhoneNumber, 'NATIONAL') ?>
 
 or:
 
-    <?php echo $view['phone_number_format']->format($myPhoneNumber, \libphonenumber\PhoneNumberFormat::NATIONAL) ?>
+    <?php echo $view['phone_number_helper']->format($myPhoneNumber, \libphonenumber\PhoneNumberFormat::NATIONAL) ?>
 
 By default phone numbers are formatted in the `libphonenumber\PhoneNumberFormat::INTERNATIONAL` format.
+
+###### isType()
+
+The `isType()` method in the `phone_number_helper` takes two arguments: a `libphonenumber\PhoneNumber` object and an optional `libphonenumber\PhoneNumberType` constant name or value.
+
+For example, to check if $myPhoneNumber` is a `libphonenumber\PhoneNumberType::MOBILE` type:
+
+    <?php if $view['phone_number_helper']->isType($myPhoneNumber, 'MOBILE'): ?>
+    ...
+    <?php endif; ?>
+
+or:
+
+    <?php if $view['phone_number_helper']->isType($myPhoneNumber, \libphonenumber\PhoneNumberType::MOBILE): ?>
+    ...
+    <?php endif; ?>
 
 ### Serializing `libphonenumber\PhoneNumber` objects
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ By default phone numbers are formatted in the `libphonenumber\PhoneNumberFormat:
 
 ###### phone_number_is_type
 
-The `phone_number_is_type` filter can be used to check a phone number against a type: A `libphonenumber\PhoneNumberType` constant name must be passed to specify to which type a number has to match.
+The `phone_number_of_type` test can be used to check a phone number against a type: A `libphonenumber\PhoneNumberType` constant name must be passed to specify to which type a number has to match.
 
 For example, to check if an object called `myPhoneNumber` is a `libphonenumber\PhoneNumberType::MOBILE` type:
 
-    {% if myPhoneNumber|phone_number_is_type('MOBILE') }} %} ... {% endif %}
+    {% if myPhoneNumber is phone_number_of_type('MOBILE') }} %} ... {% endif %}
 
 #### PHP template
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ By default phone numbers are formatted in the `libphonenumber\PhoneNumberFormat:
 
 ###### phone_number_is_type
 
-The `phone_number_is_type` function takes two arguments: a `libphonenumber\PhoneNumber` object and an optional `libphonenumber\PhoneNumberType` constant name.
+The `phone_number_is_type` filter can be used to check a phone number against a type: A `libphonenumber\PhoneNumberType` constant name must be passed to specify to which type a number has to match.
 
 For example, to check if an object called `myPhoneNumber` is a `libphonenumber\PhoneNumberType::MOBILE` type:
 
-    {% if phone_number_is_type(myPhoneNumber, 'MOBILE') }} %} ... {% endif %}
+    {% if myPhoneNumber|phone_number_is_type('MOBILE') }} %} ... {% endif %}
 
 #### PHP template
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -30,6 +30,8 @@
 
         <service id="misd_phone_number.templating.helper" class="Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper">
             <tag name="templating.helper" alias="phone_number_helper"/>
+            <!-- phone_number_format is deprecated and will be removed in 2.0 (use phone_number_helper instead) -->
+            <tag name="templating.helper" alias="phone_number_format"/>
             <argument type="service" id="libphonenumber.phone_number_util"/>
         </service>
 
@@ -41,7 +43,7 @@
         <service id="misd_phone_number.form.type" class="Misd\PhoneNumberBundle\Form\Type\PhoneNumberType">
             <tag name="form.type" alias="tel"/>
         </service>
-        
+
         <service id="misd_phone_number.serializer.handler" class="Misd\PhoneNumberBundle\Serializer\Handler\PhoneNumberHandler">
             <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="serialization" format="json" method="serializePhoneNumber"/>
             <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="deserialization" format="json" method="deserializePhoneNumberFromJson"/>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,7 +12,9 @@
         <parameter key="libphonenumber.phone_number_to_carrier_mapper.class">libphonenumber\PhoneNumberToCarrierMapper</parameter>
         <parameter key="libphonenumber.phone_number_to_time_zones_mapper.class">libphonenumber\PhoneNumberToTimeZonesMapper</parameter>
         <parameter key="misd_phone_number.templating.helper.class">Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper</parameter>
+        <parameter key="misd_phone_number.templating.helper.format.class">%misd_phone_number.templating.helper.class%</parameter>
         <parameter key="misd_phone_number.twig.extension.class">Misd\PhoneNumberBundle\Twig\Extension\PhoneNumberHelperExtension</parameter>
+        <parameter key="misd_phone_number.twig.extension.format.class">%misd_phone_number.twig.extension.class%</parameter>
         <parameter key="misd_phone_number.form.type.class">Misd\PhoneNumberBundle\Form\Type\PhoneNumberType</parameter>
         <parameter key="misd_phone_number.serializer.handler.class">Misd\PhoneNumberBundle\Serializer\Handler\PhoneNumberHandler</parameter>
     </parameters>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -29,7 +29,8 @@
 
         <service id="libphonenumber.phone_number_to_time_zones_mapper" class="libphonenumber\PhoneNumberToTimeZonesMapper"/>
 
-        <service id="misd_phone_number.templating.helper" class="Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper">
+        <service id="misd_phone_number.templating.helper"
+                 class="Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper">
             <tag name="templating.helper" alias="phone_number_helper"/>
             <!-- phone_number_format is deprecated and will be removed in 2.0 (use phone_number_helper instead) -->
             <tag name="templating.helper" alias="phone_number_format"/>
@@ -37,7 +38,8 @@
 
         </service>
 
-        <service id="misd_phone_number.twig.extension.format" class="Misd\PhoneNumberBundle\Twig\Extension\PhoneNumberHelperExtension" public="false">
+        <service id="misd_phone_number.twig.extension.format" class="Misd\PhoneNumberBundle\Twig\Extension\PhoneNumberHelperExtension"
+                 public="false">
             <tag name="twig.extension"/>
             <argument type="service" id="misd_phone_number.templating.helper"/>
         </service>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,8 +11,8 @@
         <parameter key="libphonenumber.short_number_info.class">libphonenumber\ShortNumberInfo</parameter>
         <parameter key="libphonenumber.phone_number_to_carrier_mapper.class">libphonenumber\PhoneNumberToCarrierMapper</parameter>
         <parameter key="libphonenumber.phone_number_to_time_zones_mapper.class">libphonenumber\PhoneNumberToTimeZonesMapper</parameter>
-        <parameter key="misd_phone_number.templating.helper.format.class">Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberFormatHelper</parameter>
-        <parameter key="misd_phone_number.twig.extension.format.class">Misd\PhoneNumberBundle\Twig\Extension\PhoneNumberFormatExtension</parameter>
+        <parameter key="misd_phone_number.templating.helper.class">Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper</parameter>
+        <parameter key="misd_phone_number.twig.extension.class">Misd\PhoneNumberBundle\Twig\Extension\PhoneNumberHelperExtension</parameter>
         <parameter key="misd_phone_number.form.type.class">Misd\PhoneNumberBundle\Form\Type\PhoneNumberType</parameter>
         <parameter key="misd_phone_number.serializer.handler.class">Misd\PhoneNumberBundle\Serializer\Handler\PhoneNumberHandler</parameter>
     </parameters>
@@ -29,17 +29,14 @@
 
         <service id="libphonenumber.phone_number_to_time_zones_mapper" class="libphonenumber\PhoneNumberToTimeZonesMapper"/>
 
-        <service id="misd_phone_number.templating.helper.format"
-                 class="Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberFormatHelper">
-            <tag name="templating.helper" alias="phone_number_format"/>
+        <service id="misd_phone_number.templating.helper" class="Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper">
+            <tag name="templating.helper" alias="phone_number_helper"/>
             <argument type="service" id="libphonenumber.phone_number_util"/>
-
         </service>
 
-        <service id="misd_phone_number.twig.extension.format" class="Misd\PhoneNumberBundle\Twig\Extension\PhoneNumberFormatExtension"
-                 public="false">
+        <service id="misd_phone_number.twig.extension.format" class="Misd\PhoneNumberBundle\Twig\Extension\PhoneNumberHelperExtension" public="false">
             <tag name="twig.extension"/>
-            <argument type="service" id="misd_phone_number.templating.helper.format"/>
+            <argument type="service" id="misd_phone_number.templating.helper"/>
         </service>
 
         <service id="misd_phone_number.form.type" class="Misd\PhoneNumberBundle\Form\Type\PhoneNumberType">

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -18,7 +18,6 @@
     </parameters>
 
     <services>
-
         <service id="libphonenumber.phone_number_util" class="libphonenumber\PhoneNumberUtil"/>
 
         <service id="libphonenumber.phone_number_offline_geocoder" class="libphonenumber\geocoding\PhoneNumberOfflineGeocoder"/>
@@ -42,18 +41,13 @@
         <service id="misd_phone_number.form.type" class="Misd\PhoneNumberBundle\Form\Type\PhoneNumberType">
             <tag name="form.type" alias="tel"/>
         </service>
-
+        
         <service id="misd_phone_number.serializer.handler" class="Misd\PhoneNumberBundle\Serializer\Handler\PhoneNumberHandler">
-            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="serialization"
-                 format="json" method="serializePhoneNumber"/>
-            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="deserialization"
-                 format="json" method="deserializePhoneNumberFromJson"/>
-            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="serialization"
-                 format="xml" method="serializePhoneNumber"/>
-            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="deserialization"
-                 format="xml" method="deserializePhoneNumberFromXml"/>
-            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="serialization"
-                 format="yml" method="serializePhoneNumber"/>
+            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="serialization" format="json" method="serializePhoneNumber"/>
+            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="deserialization" format="json" method="deserializePhoneNumberFromJson"/>
+            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="serialization" format="xml" method="serializePhoneNumber"/>
+            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="deserialization" format="xml" method="deserializePhoneNumberFromXml"/>
+            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="serialization" format="yml" method="serializePhoneNumber"/>
             <argument type="service" id="libphonenumber.phone_number_util"/>
         </service>
 
@@ -63,5 +57,4 @@
             <argument type="service" id="libphonenumber.phone_number_util" />
         </service>
     </services>
-
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -18,6 +18,7 @@
     </parameters>
 
     <services>
+
         <service id="libphonenumber.phone_number_util" class="libphonenumber\PhoneNumberUtil"/>
 
         <service id="libphonenumber.phone_number_offline_geocoder" class="libphonenumber\geocoding\PhoneNumberOfflineGeocoder"/>
@@ -33,6 +34,7 @@
             <!-- phone_number_format is deprecated and will be removed in 2.0 (use phone_number_helper instead) -->
             <tag name="templating.helper" alias="phone_number_format"/>
             <argument type="service" id="libphonenumber.phone_number_util"/>
+
         </service>
 
         <service id="misd_phone_number.twig.extension.format" class="Misd\PhoneNumberBundle\Twig\Extension\PhoneNumberHelperExtension" public="false">
@@ -45,11 +47,16 @@
         </service>
 
         <service id="misd_phone_number.serializer.handler" class="Misd\PhoneNumberBundle\Serializer\Handler\PhoneNumberHandler">
-            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="serialization" format="json" method="serializePhoneNumber"/>
-            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="deserialization" format="json" method="deserializePhoneNumberFromJson"/>
-            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="serialization" format="xml" method="serializePhoneNumber"/>
-            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="deserialization" format="xml" method="deserializePhoneNumberFromXml"/>
-            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="serialization" format="yml" method="serializePhoneNumber"/>
+            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="serialization"
+                 format="json" method="serializePhoneNumber"/>
+            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="deserialization"
+                 format="json" method="deserializePhoneNumberFromJson"/>
+            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="serialization"
+                 format="xml" method="serializePhoneNumber"/>
+            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="deserialization"
+                 format="xml" method="deserializePhoneNumberFromXml"/>
+            <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="serialization"
+                 format="yml" method="serializePhoneNumber"/>
             <argument type="service" id="libphonenumber.phone_number_util"/>
         </service>
 
@@ -59,4 +66,5 @@
             <argument type="service" id="libphonenumber.phone_number_util" />
         </service>
     </services>
+
 </container>

--- a/Templating/Helper/PhoneNumberFormatHelper.php
+++ b/Templating/Helper/PhoneNumberFormatHelper.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony2 PhoneNumberBundle.
+ *
+ * (c) University of Cambridge
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Misd\PhoneNumberBundle\Templating\Helper;
+
+/**
+ * @deprecated PhoneNumberFormatHelper is deprecated and will be removed in 2.0. Use PhoneNumberHelper instead
+ */
+class PhoneNumberFormatHelper extends PhoneNumberHelper {}

--- a/Templating/Helper/PhoneNumberHelper.php
+++ b/Templating/Helper/PhoneNumberHelper.php
@@ -13,14 +13,15 @@ namespace Misd\PhoneNumberBundle\Templating\Helper;
 
 use libphonenumber\PhoneNumber;
 use libphonenumber\PhoneNumberFormat;
+use libphonenumber\PhoneNumberType;
 use libphonenumber\PhoneNumberUtil;
 use Misd\PhoneNumberBundle\Exception\InvalidArgumentException;
 use Symfony\Component\Templating\Helper\HelperInterface;
 
 /**
- * Phone number format templating helper.
+ * Phone number templating helper.
  */
-class PhoneNumberFormatHelper implements HelperInterface
+class PhoneNumberHelper implements HelperInterface
 {
     /**
      * Phone number utility.
@@ -93,5 +94,17 @@ class PhoneNumberFormatHelper implements HelperInterface
         }
 
         return $this->phoneNumberUtil->format($phoneNumber, $format);
+    }
+
+    /**
+     * Returns true if PhoneNumber is a mobile or "fixed line or mobile" number.
+     *
+     * @param PhoneNumber $phoneNumber
+     *
+     * @return bool
+     */
+    public function isMobile(PhoneNumber $phoneNumber)
+    {
+        return in_array($this->phoneNumberUtil->getNumberType($phoneNumber), array(PhoneNumberType::MOBILE, PhoneNumberType::FIXED_LINE_OR_MOBILE));
     }
 }

--- a/Templating/Helper/PhoneNumberHelper.php
+++ b/Templating/Helper/PhoneNumberHelper.php
@@ -68,7 +68,7 @@ class PhoneNumberHelper implements HelperInterface
      */
     public function getName()
     {
-        return 'phone_number_format';
+        return 'phone_number_helper';
     }
 
     /**
@@ -97,14 +97,25 @@ class PhoneNumberHelper implements HelperInterface
     }
 
     /**
-     * Returns true if PhoneNumber is a mobile or "fixed line or mobile" number.
-     *
-     * @param PhoneNumber $phoneNumber
+     * @param PhoneNumber $phoneNumber Phone number.
+     * @param int|string  $type      PhoneNumberType, or PhoneNumberType constant name.
      *
      * @return bool
+     *
+     * @throws InvalidArgumentException If type argument is invalid.
      */
-    public function isMobile(PhoneNumber $phoneNumber)
+    public function isType(PhoneNumber $phoneNumber, $type = PhoneNumberType::UNKNOWN)
     {
-        return in_array($this->phoneNumberUtil->getNumberType($phoneNumber), array(PhoneNumberType::MOBILE, PhoneNumberType::FIXED_LINE_OR_MOBILE));
+        if (true === is_string($type)) {
+            $constant = '\libphonenumber\PhoneNumberType::' . $type;
+
+            if (false === defined($constant)) {
+                throw new InvalidArgumentException('The format must be either a constant value or name in libphonenumber\PhoneNumberType');
+            }
+
+            $type = constant('\libphonenumber\PhoneNumberType::' . $type);
+        }
+
+        return $this->phoneNumberUtil->getNumberType($phoneNumber) === $type ? true : false;
     }
 }

--- a/Tests/DependencyInjection/MisdPhoneNumberExtensionTest.php
+++ b/Tests/DependencyInjection/MisdPhoneNumberExtensionTest.php
@@ -65,13 +65,13 @@ class MisdPhoneNumberExtensionTest extends TestCase
         }
 
         $this->assertHasService(
-          'misd_phone_number.templating.helper.format',
-          'Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberFormatHelper'
+          'misd_phone_number.templating.helper',
+          'Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper'
         );
         $this->assertServiceHasTag(
-          'misd_phone_number.templating.helper.format',
+          'misd_phone_number.templating.helper',
           'templating.helper',
-          array('alias' => 'phone_number_format')
+          array('alias' => 'phone_number_helper')
         );
         $this->assertHasService(
           'misd_phone_number.form.type',

--- a/Tests/DependencyInjection/MisdPhoneNumberExtensionTest.php
+++ b/Tests/DependencyInjection/MisdPhoneNumberExtensionTest.php
@@ -38,6 +38,7 @@ class MisdPhoneNumberExtensionTest extends TestCase
           'libphonenumber.phone_number_util',
           'libphonenumber\PhoneNumberUtil'
         );
+
         if (class_exists('libphonenumber\geocoding\PhoneNumberOfflineGeocoder') && extension_loaded('intl')) {
             $this->assertHasService(
               'libphonenumber.phone_number_offline_geocoder',
@@ -62,6 +63,7 @@ class MisdPhoneNumberExtensionTest extends TestCase
               'libphonenumber\PhoneNumberToTimeZonesMapper'
             );
         }
+
         $this->assertHasService(
           'misd_phone_number.templating.helper.format',
           'Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberFormatHelper'

--- a/Tests/DependencyInjection/MisdPhoneNumberExtensionTest.php
+++ b/Tests/DependencyInjection/MisdPhoneNumberExtensionTest.php
@@ -38,7 +38,6 @@ class MisdPhoneNumberExtensionTest extends TestCase
           'libphonenumber.phone_number_util',
           'libphonenumber\PhoneNumberUtil'
         );
-
         if (class_exists('libphonenumber\geocoding\PhoneNumberOfflineGeocoder') && extension_loaded('intl')) {
             $this->assertHasService(
               'libphonenumber.phone_number_offline_geocoder',
@@ -63,7 +62,6 @@ class MisdPhoneNumberExtensionTest extends TestCase
               'libphonenumber\PhoneNumberToTimeZonesMapper'
             );
         }
-
         $this->assertHasService(
           'misd_phone_number.templating.helper',
           'Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper'

--- a/Tests/DependencyInjection/MisdPhoneNumberExtensionTest.php
+++ b/Tests/DependencyInjection/MisdPhoneNumberExtensionTest.php
@@ -71,6 +71,14 @@ class MisdPhoneNumberExtensionTest extends TestCase
           'templating.helper',
           array('alias' => 'phone_number_helper')
         );
+
+        // Assert deprecated 'phone_number_format' alias
+        $this->assertServiceHasTag(
+            'misd_phone_number.templating.helper',
+            'templating.helper',
+            array('alias' => 'phone_number_format')
+        );
+
         $this->assertHasService(
           'misd_phone_number.form.type',
           'Misd\PhoneNumberBundle\Form\Type\PhoneNumberType'

--- a/Tests/Form/DataTransformer/PhoneNumberToArrayTransformerTest.php
+++ b/Tests/Form/DataTransformer/PhoneNumberToArrayTransformerTest.php
@@ -166,12 +166,12 @@ class PhoneNumberToArrayTransformerTest extends TestCase
             array(
                 array('GB'),
                 array('country' => 'GB', 'number' => '01234 567890'),
-                'Country Code: 44 National Number: 1234567890 Country Code Source: ',
+                '+441234567890',
             ),
             array(
                 array('GB'),
                 array('country' => 'GB', 'number' => '+44 1234 567890'),
-                'Country Code: 44 National Number: 1234567890 Country Code Source: ',
+                '+441234567890',
             ),
             array(// Country code not in list.
                 array('US'),

--- a/Tests/Form/DataTransformer/PhoneNumberToArrayTransformerTest.php
+++ b/Tests/Form/DataTransformer/PhoneNumberToArrayTransformerTest.php
@@ -166,12 +166,12 @@ class PhoneNumberToArrayTransformerTest extends TestCase
             array(
                 array('GB'),
                 array('country' => 'GB', 'number' => '01234 567890'),
-                '+441234567890',
+                'Country Code: 44 National Number: 1234567890 Country Code Source: ',
             ),
             array(
                 array('GB'),
                 array('country' => 'GB', 'number' => '+44 1234 567890'),
-                '+441234567890',
+                'Country Code: 44 National Number: 1234567890 Country Code Source: ',
             ),
             array(// Country code not in list.
                 array('US'),

--- a/Tests/Templating/Helper/PhoneNumberHelperTest.php
+++ b/Tests/Templating/Helper/PhoneNumberHelperTest.php
@@ -12,20 +12,20 @@
 namespace Misd\PhoneNumberBundle\Tests\Templating\Helper;
 
 use libphonenumber\PhoneNumberFormat;
-use Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberFormatHelper;
+use Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper;
 use PHPUnit_Framework_TestCase as TestCase;
 
 /**
- * Phone number format templating helper test.
+ * Phone number templating helper test.
  */
-class PhoneNumberFormatHelperTest extends TestCase
+class PhoneNumberHelperTest extends TestCase
 {
     public function testConstructor()
     {
         $phoneNumberUtil = $this->getMockBuilder('libphonenumber\PhoneNumberUtil')
             ->disableOriginalConstructor()->getMock();
 
-        $helper = new PhoneNumberFormatHelper($phoneNumberUtil);
+        $helper = new PhoneNumberHelper($phoneNumberUtil);
 
         $this->assertInstanceOf('Symfony\Component\Templating\Helper\HelperInterface', $helper);
     }
@@ -35,7 +35,7 @@ class PhoneNumberFormatHelperTest extends TestCase
         $phoneNumberUtil = $this->getMockBuilder('libphonenumber\PhoneNumberUtil')
             ->disableOriginalConstructor()->getMock();
 
-        $helper = new PhoneNumberFormatHelper($phoneNumberUtil);
+        $helper = new PhoneNumberHelper($phoneNumberUtil);
 
         $helper->setCharset('test');
 
@@ -47,7 +47,7 @@ class PhoneNumberFormatHelperTest extends TestCase
         $phoneNumberUtil = $this->getMockBuilder('libphonenumber\PhoneNumberUtil')
             ->disableOriginalConstructor()->getMock();
 
-        $helper = new PhoneNumberFormatHelper($phoneNumberUtil);
+        $helper = new PhoneNumberHelper($phoneNumberUtil);
 
         $this->assertTrue(is_string($helper->getName()));
     }
@@ -63,7 +63,7 @@ class PhoneNumberFormatHelperTest extends TestCase
             ->disableOriginalConstructor()->getMock();
         $phoneNumberUtil->expects($this->once())->method('format')->with($phoneNumber, $expectedFormat);
 
-        $helper = new PhoneNumberFormatHelper($phoneNumberUtil);
+        $helper = new PhoneNumberHelper($phoneNumberUtil);
 
         $helper->format($phoneNumber, $format);
     }
@@ -90,7 +90,7 @@ class PhoneNumberFormatHelperTest extends TestCase
         $phoneNumberUtil = $this->getMockBuilder('libphonenumber\PhoneNumberUtil')
             ->disableOriginalConstructor()->getMock();
 
-        $helper = new PhoneNumberFormatHelper($phoneNumberUtil);
+        $helper = new PhoneNumberHelper($phoneNumberUtil);
 
         $helper->format($phoneNumber, 'foo');
     }

--- a/Tests/Templating/Helper/PhoneNumberHelperTest.php
+++ b/Tests/Templating/Helper/PhoneNumberHelperTest.php
@@ -12,6 +12,7 @@
 namespace Misd\PhoneNumberBundle\Tests\Templating\Helper;
 
 use libphonenumber\PhoneNumberFormat;
+use Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberFormatHelper;
 use Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper;
 use PHPUnit_Framework_TestCase as TestCase;
 
@@ -93,5 +94,14 @@ class PhoneNumberHelperTest extends TestCase
         $helper = new PhoneNumberHelper($phoneNumberUtil);
 
         $helper->format($phoneNumber, 'foo');
+    }
+
+    public function testDeprecatedClassName() {
+        $phoneNumberUtil = $this->getMockBuilder('libphonenumber\PhoneNumberUtil')
+            ->disableOriginalConstructor()->getMock();
+
+        $helper = new PhoneNumberFormatHelper($phoneNumberUtil);
+
+        $this->assertInstanceOf('Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper', $helper);
     }
 }

--- a/Tests/Twig/Extension/PhoneNumberHelperExtensionTest.php
+++ b/Tests/Twig/Extension/PhoneNumberHelperExtensionTest.php
@@ -48,7 +48,7 @@ class PhoneNumberHelperExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $functions = $this->extension->getFunctions();
 
-        $this->assertCount(1, $functions);
+        $this->assertCount(2, $functions);
         $this->assertInstanceOf('Twig_SimpleFunction', $functions[0]);
         $this->assertSame('phone_number_format', $functions[0]->getName());
 
@@ -56,6 +56,14 @@ class PhoneNumberHelperExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($this->helper, $callable[0]);
         $this->assertSame('format', $callable[1]);
+
+        $this->assertInstanceOf('Twig_SimpleFunction', $functions[1]);
+        $this->assertSame('phone_number_is_type', $functions[1]->getName());
+
+        $callable = $functions[1]->getCallable();
+
+        $this->assertSame($this->helper, $callable[0]);
+        $this->assertSame('isType', $callable[1]);
     }
 
     public function testGetFilters()

--- a/Tests/Twig/Extension/PhoneNumberHelperExtensionTest.php
+++ b/Tests/Twig/Extension/PhoneNumberHelperExtensionTest.php
@@ -11,30 +11,32 @@
 
 namespace Misd\PhoneNumberBundle\Tests\Twig\Extension;
 
-use Misd\PhoneNumberBundle\Twig\Extension\PhoneNumberFormatExtension;
+
+use Misd\PhoneNumberBundle\Twig\Extension\PhoneNumberHelperExtension;
+
 
 /**
- * Phone number format Twig extension test.
+ * Phone number helper Twig extension test.
  */
-class PhoneNumberFormatExtensionTest extends \PHPUnit_Framework_TestCase
+class PhoneNumberHelperExtensionTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberFormatHelper
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper
      */
     private $helper;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Misd\PhoneNumberBundle\Twig\Extension\PhoneNumberFormatExtension
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Misd\PhoneNumberBundle\Twig\Extension\PhoneNumberHelperExtension
      */
     private $extension;
 
     protected function setUp()
     {
-        $this->helper = $this->getMockBuilder('Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberFormatHelper')
+        $this->helper = $this->getMockBuilder('Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->extension = new PhoneNumberFormatExtension($this->helper);
+        $this->extension = new PhoneNumberHelperExtension($this->helper);
     }
 
     public function testConstructor()
@@ -58,16 +60,24 @@ class PhoneNumberFormatExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetFilters()
     {
-        $filters = $this->extension->getFunctions();
+        $filters = $this->extension->getFilters();
 
-        $this->assertCount(1, $filters);
-        $this->assertInstanceOf('Twig_SimpleFunction', $filters[0]);
+        $this->assertCount(2, $filters);
+        $this->assertInstanceOf('Twig_SimpleFilter', $filters[0]);
         $this->assertSame('phone_number_format', $filters[0]->getName());
 
         $callable = $filters[0]->getCallable();
 
         $this->assertSame($this->helper, $callable[0]);
         $this->assertSame('format', $callable[1]);
+
+        $this->assertInstanceOf('Twig_SimpleFilter', $filters[1]);
+        $this->assertSame('phone_number_is_mobile', $filters[1]->getName());
+
+        $callable = $filters[1]->getCallable();
+
+        $this->assertSame($this->helper, $callable[0]);
+        $this->assertSame('isMobile', $callable[1]);
     }
 
     public function testGetName()

--- a/Tests/Twig/Extension/PhoneNumberHelperExtensionTest.php
+++ b/Tests/Twig/Extension/PhoneNumberHelperExtensionTest.php
@@ -72,12 +72,12 @@ class PhoneNumberHelperExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('format', $callable[1]);
 
         $this->assertInstanceOf('Twig_SimpleFilter', $filters[1]);
-        $this->assertSame('phone_number_is_mobile', $filters[1]->getName());
+        $this->assertSame('phone_number_is_type', $filters[1]->getName());
 
         $callable = $filters[1]->getCallable();
 
         $this->assertSame($this->helper, $callable[0]);
-        $this->assertSame('isMobile', $callable[1]);
+        $this->assertSame('isType', $callable[1]);
     }
 
     public function testGetName()

--- a/Tests/Twig/Extension/PhoneNumberHelperExtensionTest.php
+++ b/Tests/Twig/Extension/PhoneNumberHelperExtensionTest.php
@@ -70,7 +70,7 @@ class PhoneNumberHelperExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $filters = $this->extension->getFilters();
 
-        $this->assertCount(2, $filters);
+        $this->assertCount(1, $filters);
         $this->assertInstanceOf('Twig_SimpleFilter', $filters[0]);
         $this->assertSame('phone_number_format', $filters[0]->getName());
 
@@ -78,11 +78,17 @@ class PhoneNumberHelperExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($this->helper, $callable[0]);
         $this->assertSame('format', $callable[1]);
+    }
 
-        $this->assertInstanceOf('Twig_SimpleFilter', $filters[1]);
-        $this->assertSame('phone_number_is_type', $filters[1]->getName());
+    public function testGetTests()
+    {
+        $tests = $this->extension->getTests();
 
-        $callable = $filters[1]->getCallable();
+        $this->assertCount(1, $tests);
+        $this->assertInstanceOf('Twig_SimpleTest', $tests[0]);
+        $this->assertSame('phone_number_of_type', $tests[0]->getName());
+
+        $callable = $tests[0]->getCallable();
 
         $this->assertSame($this->helper, $callable[0]);
         $this->assertSame('isType', $callable[1]);

--- a/Twig/Extension/PhoneNumberFormatExtension.php
+++ b/Twig/Extension/PhoneNumberFormatExtension.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony2 PhoneNumberBundle.
+ *
+ * (c) University of Cambridge
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Misd\PhoneNumberBundle\Twig\Extension;
+
+use Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper;
+use Twig_Extension as Extension;
+use Twig_SimpleFunction as SimpleFunction;
+
+/**
+ * @deprecated PhoneNumberFormatExtension is deprecated and will be removed in 2.0. Use PhoneNumberHelperExtension instead
+ */
+class PhoneNumberFormatExtension extends PhoneNumberHelperExtension {}

--- a/Twig/Extension/PhoneNumberFormatExtension.php
+++ b/Twig/Extension/PhoneNumberFormatExtension.php
@@ -11,10 +11,6 @@
 
 namespace Misd\PhoneNumberBundle\Twig\Extension;
 
-use Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper;
-use Twig_Extension as Extension;
-use Twig_SimpleFunction as SimpleFunction;
-
 /**
  * @deprecated PhoneNumberFormatExtension is deprecated and will be removed in 2.0. Use PhoneNumberHelperExtension instead
  */

--- a/Twig/Extension/PhoneNumberHelperExtension.php
+++ b/Twig/Extension/PhoneNumberHelperExtension.php
@@ -53,7 +53,16 @@ class PhoneNumberHelperExtension extends \Twig_Extension
     {
         return array(
             new \Twig_SimpleFilter('phone_number_format', array($this->helper, 'format')),
-            new \Twig_SimpleFilter('phone_number_is_type', array($this->helper, 'isType')),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTests()
+    {
+        return array(
+            new \Twig_SimpleTest('phone_number_of_type', array($this->helper, 'isType')),
         );
     }
 

--- a/Twig/Extension/PhoneNumberHelperExtension.php
+++ b/Twig/Extension/PhoneNumberHelperExtension.php
@@ -11,28 +11,26 @@
 
 namespace Misd\PhoneNumberBundle\Twig\Extension;
 
-use Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberFormatHelper;
+use Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper;
 
 /**
- * Phone number format Twig extension.
- *
- * @author Stefano Arlandini <sarlandini@alice.it>
+ * Phone number helper Twig extension.
  */
-class PhoneNumberFormatExtension extends \Twig_Extension
+class PhoneNumberHelperExtension extends \Twig_Extension
 {
     /**
-     * Phone number format helper.
+     * Phone number helper.
      *
-     * @var PhoneNumberFormatHelper
+     * @var PhoneNumberHelper
      */
     protected $helper;
 
     /**
      * Constructor.
      *
-     * @param PhoneNumberFormatHelper $helper Phone number format helper.
+     * @param PhoneNumberHelper $helper Phone number helper.
      */
-    public function __construct(PhoneNumberFormatHelper $helper)
+    public function __construct(PhoneNumberHelper $helper)
     {
         $this->helper = $helper;
     }
@@ -54,6 +52,7 @@ class PhoneNumberFormatExtension extends \Twig_Extension
     {
         return array(
             new \Twig_SimpleFilter('phone_number_format', array($this->helper, 'format')),
+            new \Twig_SimpleFilter('phone_number_is_mobile', array($this->helper, 'isMobile')),
         );
     }
 
@@ -62,6 +61,6 @@ class PhoneNumberFormatExtension extends \Twig_Extension
      */
     public function getName()
     {
-        return 'phone_number_format';
+        return 'phone_number_helper';
     }
 }

--- a/Twig/Extension/PhoneNumberHelperExtension.php
+++ b/Twig/Extension/PhoneNumberHelperExtension.php
@@ -52,7 +52,7 @@ class PhoneNumberHelperExtension extends \Twig_Extension
     {
         return array(
             new \Twig_SimpleFilter('phone_number_format', array($this->helper, 'format')),
-            new \Twig_SimpleFilter('phone_number_is_mobile', array($this->helper, 'isMobile')),
+            new \Twig_SimpleFilter('phone_number_is_type', array($this->helper, 'isType')),
         );
     }
 

--- a/Twig/Extension/PhoneNumberHelperExtension.php
+++ b/Twig/Extension/PhoneNumberHelperExtension.php
@@ -41,7 +41,8 @@ class PhoneNumberHelperExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('phone_number_format', array($this->helper, 'format'), array('deprecated' => '1.2'))
+            new \Twig_SimpleFunction('phone_number_format', array($this->helper, 'format'), array('deprecated' => '1.2')),
+            new \Twig_SimpleFunction('phone_number_is_type', array($this->helper, 'isType'), array('deprecated' => '1.2')),
         );
     }
 


### PR DESCRIPTION
solves #30 

there is a BC break when using PHP template because the helper is renamed to `phone_number_helper` from `phone_number_format`.
