### PR TITLE
Replace translation messages with keys

### DIFF
--- a/Form/Type/PhoneNumberType.php
+++ b/Form/Type/PhoneNumberType.php
@@ -67,7 +67,7 @@ class PhoneNumberType extends AbstractType
                 'compound' => false,
                 'default_region' => PhoneNumberUtil::UNKNOWN_REGION,
                 'format' => PhoneNumberFormat::INTERNATIONAL,
-                'invalid_message' => 'This value is not a valid phone number.',
+                'invalid_message' => 'invalid_phone_number',
             )
         );
     }

--- a/Resources/translations/validators.bs.xlf
+++ b/Resources/translations/validators.bs.xlf
@@ -3,15 +3,15 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
-                <source>This value is not a valid phone number.</source>
+                <source>invalid_phone_number</source>
                 <target>Ova vrijednost nije ispravan broj telefona.</target>
             </trans-unit>
             <trans-unit id="2">
-                <source>This value is not a valid fixed-line number.</source>
+                <source>invalid_fixed_phone_number</source>
                 <target>Ova vrijednost nije ispravan broj fiksne linije.</target>
             </trans-unit>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>Ova vrijednost nije ispravan broj mobitela.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.bs_Cyrl.xlf
+++ b/Resources/translations/validators.bs_Cyrl.xlf
@@ -3,15 +3,15 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
-                <source>This value is not a valid phone number.</source>
+                <source>invalid_phone_number</source>
                 <target>Ова вриједност није исправан број телефона.</target>
             </trans-unit>
             <trans-unit id="2">
-                <source>This value is not a valid fixed-line number.</source>
+                <source>invalid_fixed_phone_number</source>
                 <target>Ова вриједност није исправан број фиксне линије.</target>
             </trans-unit>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>Ова вриједност није исправан број мобитела.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.de.xlf
+++ b/Resources/translations/validators.de.xlf
@@ -3,15 +3,15 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
-                <source>This value is not a valid phone number.</source>
+                <source>invalid_phone_number</source>
                 <target>Dieser Wert ist keine gültige Telefonnummer.</target>
             </trans-unit>
             <trans-unit id="2">
-                <source>This value is not a valid fixed-line number.</source>
+                <source>invalid_fixed_phone_number</source>
                 <target>Dieser Wert ist keine gültige Festnetznummer.</target>
             </trans-unit>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>Dieser Wert ist keine gültige Mobilnummer.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.en.xlf
+++ b/Resources/translations/validators.en.xlf
@@ -3,15 +3,15 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
-                <source>This value is not a valid phone number.</source>
+                <source>invalid_phone_number</source>
                 <target>This value is not a valid phone number.</target>
             </trans-unit>
             <trans-unit id="2">
-                <source>This value is not a valid fixed-line number.</source>
+                <source>invalid_fixed_phone_number</source>
                 <target>This value is not a valid fixed-line number.</target>
             </trans-unit>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>This value is not a valid mobile number.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.en_CA.xlf
+++ b/Resources/translations/validators.en_CA.xlf
@@ -3,7 +3,7 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>This value is not a valid cell number.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.en_PH.xlf
+++ b/Resources/translations/validators.en_PH.xlf
@@ -3,7 +3,7 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>This value is not a valid handphone number.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.en_SG.xlf
+++ b/Resources/translations/validators.en_SG.xlf
@@ -3,7 +3,7 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>This value is not a valid handphone number.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.en_US.xlf
+++ b/Resources/translations/validators.en_US.xlf
@@ -3,7 +3,7 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>This value is not a valid cell number.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.en_ZA.xlf
+++ b/Resources/translations/validators.en_ZA.xlf
@@ -3,7 +3,7 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>This value is not a valid cell number.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.es.xlf
+++ b/Resources/translations/validators.es.xlf
@@ -3,15 +3,15 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
-                <source>This value is not a valid phone number.</source>
+                <source>invalid_phone_number</source>
                 <target>Este valor no es un número de teléfono válido.</target>
             </trans-unit>
             <trans-unit id="2">
-                <source>This value is not a valid fixed-line number.</source>
+                <source>invalid_fixed_phone_number</source>
                 <target>Este valor no es un número de línea fija válido.</target>
             </trans-unit>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>Este valor no es un número de móvil válido.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.es_419.xlf
+++ b/Resources/translations/validators.es_419.xlf
@@ -3,7 +3,7 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>Este valor no es un número de celular válido.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.fr.xlf
+++ b/Resources/translations/validators.fr.xlf
@@ -3,15 +3,15 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
-                <source>This value is not a valid phone number.</source>
+                <source>invalid_phone_number</source>
                 <target>Cette valeur n'est pas un numéro de téléphone valide.</target>
             </trans-unit>
             <trans-unit id="2">
-                <source>This value is not a valid fixed-line number.</source>
+                <source>invalid_fixed_phone_number</source>
                 <target>Cette valeur n'est pas un numéro de téléphone fixe valide.</target>
             </trans-unit>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>Cette valeur n'est pas un numéro de téléphone mobile valide.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.hr.xlf
+++ b/Resources/translations/validators.hr.xlf
@@ -3,15 +3,15 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
-                <source>This value is not a valid phone number.</source>
+                <source>invalid_phone_number</source>
                 <target>Ova vrijednost nije ispravan broj telefona.</target>
             </trans-unit>
             <trans-unit id="2">
-                <source>This value is not a valid fixed-line number.</source>
+                <source>invalid_fixed_phone_number</source>
                 <target>Ova vrijednost nije ispravan broj fiksne linije.</target>
             </trans-unit>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>Ova vrijednost nije ispravan broj mobitela.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.it.xlf
+++ b/Resources/translations/validators.it.xlf
@@ -3,15 +3,15 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
-                <source>This value is not a valid phone number.</source>
+                <source>invalid_phone_number</source>
                 <target>Questo valore non è un numero di telefono valido.</target>
             </trans-unit>
             <trans-unit id="2">
-                <source>This value is not a valid fixed-line number.</source>
+                <source>invalid_fixed_phone_number</source>
                 <target>Questo valore non è valido per una linea telefonica fissa.</target>
             </trans-unit>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>Questo valore non è valido per una linea telefonica mobile.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.nl.xlf
+++ b/Resources/translations/validators.nl.xlf
@@ -3,15 +3,15 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
-                <source>This value is not a valid phone number.</source>
+                <source>invalid_phone_number</source>
                 <target>Deze waarde is geen geldig telefoonnummer.</target>
             </trans-unit>
             <trans-unit id="2">
-                <source>This value is not a valid fixed-line number.</source>
+                <source>invalid_fixed_phone_number</source>
                 <target>Deze waarde is geen geldig vast telefoonnummer.</target>
             </trans-unit>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>Deze waarde is geen geldig mobiel telefoonnummer.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.pl.xlf
+++ b/Resources/translations/validators.pl.xlf
@@ -3,15 +3,15 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
-                <source>This value is not a valid phone number.</source>
+                <source>invalid_phone_number</source>
                 <target>To nie jest poprawny numer telefonu.</target>
             </trans-unit>
             <trans-unit id="2">
-                <source>This value is not a valid fixed-line number.</source>
+                <source>invalid_fixed_phone_number</source>
                 <target>To nie jest poprawny numer telefonu stacjonarnego.</target>
             </trans-unit>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>To nie jest poprawny numer telefonu komórkowego.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.ru.xlf
+++ b/Resources/translations/validators.ru.xlf
@@ -3,15 +3,15 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
-                <source>This value is not a valid phone number.</source>
+                <source>invalid_phone_number</source>
                 <target>Значение не является допустимым номером телефона.</target>
             </trans-unit>
             <trans-unit id="2">
-                <source>This value is not a valid fixed-line number.</source>
+                <source>invalid_fixed_phone_number</source>
                 <target>Значение не является допустимым номером фиксированной связи.</target>
             </trans-unit>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>Значение не является допустимым мобильным номером.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.sr.xlf
+++ b/Resources/translations/validators.sr.xlf
@@ -3,15 +3,15 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
-                <source>This value is not a valid phone number.</source>
+                <source>invalid_phone_number</source>
                 <target>Вредност није валидан број телефона.</target>
             </trans-unit>
             <trans-unit id="2">
-                <source>This value is not a valid fixed-line number.</source>
+                <source>invalid_fixed_phone_number</source>
                 <target>Вредност није валидан број фиксне линије.</target>
             </trans-unit>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>Вредност није валидан број мобилног.</target>
             </trans-unit>
         </body>

--- a/Resources/translations/validators.sr_Latn.xlf
+++ b/Resources/translations/validators.sr_Latn.xlf
@@ -3,15 +3,15 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
-                <source>This value is not a valid phone number.</source>
+                <source>invalid_phone_number</source>
                 <target>Vrednost nije validan broj telefona.</target>
             </trans-unit>
             <trans-unit id="2">
-                <source>This value is not a valid fixed-line number.</source>
+                <source>invalid_fixed_phone_number</source>
                 <target>Vrednost nije validan broj fiksne linije.</target>
             </trans-unit>
             <trans-unit id="3">
-                <source>This value is not a valid mobile number.</source>
+                <source>invalid_mobile_phone_number</source>
                 <target>Vrednost nije validan broj mobilnog.</target>
             </trans-unit>
         </body>

--- a/Tests/Validator/Constraints/PhoneNumberTest.php
+++ b/Tests/Validator/Constraints/PhoneNumberTest.php
@@ -55,9 +55,9 @@ class PhoneNumberTest extends TestCase
     public function messageProvider()
     {
         return array(
-            array(null, null, 'This value is not a valid phone number.'),
-            array(null, 'fixed_line', 'This value is not a valid fixed-line number.'),
-            array(null, 'mobile', 'This value is not a valid mobile number.'),
+            array(null, null, 'invalid_phone_number'),
+            array(null, 'fixed_line', 'invalid_fixed_phone_number'),
+            array(null, 'mobile', 'invalid_mobile_phone_number'),
             array('foo', null, 'foo'),
             array('foo', 'fixed_line', 'foo'),
             array('foo', 'mobile', 'foo'),

--- a/Validator/Constraints/PhoneNumber.php
+++ b/Validator/Constraints/PhoneNumber.php
@@ -27,9 +27,9 @@ class PhoneNumber extends Constraint
     const FIXED_LINE = 'fixed_line';
     const MOBILE = 'mobile';
 
-    private $anyMessage = 'This value is not a valid phone number.';
-    private $fixedLineMessage = 'This value is not a valid fixed-line number.';
-    private $mobileMessage = 'This value is not a valid mobile number.';
+    private $anyMessage = 'invalid_phone_number';
+    private $fixedLineMessage = 'invalid_fixed_phone_number';
+    private $mobileMessage = 'invalid_mobile_phone_number';
 
     public $message = null;
     public $type = self::ANY;


### PR DESCRIPTION
Value translations as keys can not be overridden by `yml` users, so it is better to use translation keys.

Next to that, tag `v1.0.5` does not contain the translation directory:

https://github.com/misd-service-development/phone-number-bundle/tree/v1.0.5/Resources

... so please release a new tag from `master` after this PR was merged.