### PR TITLE
Remove minimum-stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "symfony/twig-bundle": "Format phone numbers in Twig templates",
         "symfony/validator": "Add a validation constraint"
     },
-    "minimum-stability": "alpha",
     "autoload": {
         "psr-4": {
             "Misd\\PhoneNumberBundle\\": ""


### PR DESCRIPTION
Why should we use a minimum stability anymore?