### PR TITLE
Remove symfony/framework-bundle requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ PhoneNumberBundle
 
 This bundle integrates [Google's libphonenumber](https://github.com/googlei18n/libphonenumber) into your Symfony2 application through the [giggsey/libphonenumber-for-php](https://github.com/giggsey/libphonenumber-for-php) port.
 
+The following assumes that you are using [Symfony bundles](http://symfony.com/doc/current/book/bundles.html), but you can use individual parts if you are only using a single [Symfony component](http://symfony.com/doc/current/components/index.html) for example. 
+
 Installation
 ------------
 

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "giggsey/libphonenumber-for-php": "~5.7|~6.0|~7.0",
-        "symfony/framework-bundle": "~2.1|~3.0"
+        "giggsey/libphonenumber-for-php": "~5.7|~6.0|~7.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "~1.0",
         "jms/serializer-bundle": "~0.11|~1.0",
         "phpunit/phpunit": "~4.0",
         "symfony/form": "~2.3|~3.0",
+        "symfony/framework-bundle": "~2.1|~3.0",
         "symfony/templating": "~2.1|~3.0",
         "symfony/twig-bundle": "~2.1|~3.0",
         "symfony/validator": "~2.1|~3.0"


### PR DESCRIPTION
Although this is called a bundle, I'm wondering whether it would be useful to anyone just using Symfony components. At the moment it requires `symfony/framework-bundle`, which pulls in a whole bunch of dependencies, so couldn't realistically be used. This removes the hard constraint, so it would be possible.

It does mean that there's no Symfony version constraint, which probably isn't a good thing. (Maybe a `conflict` on `symfony/framework-bundle` would be enough? Would a conflict on `symfony/symfony` still cover individual parts?)