### PR TITLE
Allow the country choice widget to not be required

### DIFF
--- a/Form/DataTransformer/PhoneNumberToArrayTransformer.php
+++ b/Form/DataTransformer/PhoneNumberToArrayTransformer.php
@@ -74,7 +74,7 @@ class PhoneNumberToArrayTransformer implements DataTransformerInterface
             throw new TransformationFailedException('Expected an array.');
         }
 
-        if ('' === trim(implode('', $value))) {
+        if ('' === trim($value['number'])) {
             return null;
         }
 

--- a/Tests/Form/DataTransformer/PhoneNumberToArrayTransformerTest.php
+++ b/Tests/Form/DataTransformer/PhoneNumberToArrayTransformerTest.php
@@ -155,6 +155,11 @@ class PhoneNumberToArrayTransformerTest extends TestCase
             ),
             array(
                 array('GB'),
+                array('country' => 'GB', 'number' => ''),
+                null,
+            ),
+            array(
+                array('GB'),
                 array('country' => '', 'number' => 'foo'),
                 self::TRANSFORMATION_FAILED,
             ),


### PR DESCRIPTION
Fixes #81 and #85.

Currently the country subfield always returns a value, but the transformer should only care if the number subfield has a value. Without it, the field always acts as required.