### PR TITLE
Set default_region as selected country in widget country choice

### DIFF
--- a/Form/Type/PhoneNumberType.php
+++ b/Form/Type/PhoneNumberType.php
@@ -96,6 +96,10 @@ class PhoneNumberType extends AbstractType
             $countryOptions['required'] = true;
             $countryOptions['choices'] = $countryChoices;
             $countryOptions['preferred_choices'] = $options['preferred_country_choices'];
+            if($options['default_region']!= PhoneNumberUtil::UNKNOWN_REGION) {
+                $countryOptions['data'] = $options['default_region'];
+            }
+
 
             $builder
                 ->add('country', $choiceType, $countryOptions)


### PR DESCRIPTION
Hello,
This set the default_region as the default choice in the country widget list in PhoneNumberType when this option is not specified or is set to UNKNOWN_REGION