### PR TITLE
update readme to show that Symfony3 is also supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ PhoneNumberBundle
 [![Latest stable version](https://img.shields.io/packagist/v/misd/phone-number-bundle.svg?style=flat-square)](https://packagist.org/packages/misd/phone-number-bundle)
 [![License](http://img.shields.io/packagist/l/misd/phone-number-bundle.svg?style=flat-square)](https://packagist.org/packages/misd/phone-number-bundle)
 
-This bundle integrates [Google's libphonenumber](https://github.com/googlei18n/libphonenumber) into your Symfony2 application through the [giggsey/libphonenumber-for-php](https://github.com/giggsey/libphonenumber-for-php) port.
+This bundle integrates [Google's libphonenumber](https://github.com/googlei18n/libphonenumber) into your Symfony2/Symfony3 application through the [giggsey/libphonenumber-for-php](https://github.com/giggsey/libphonenumber-for-php) port.
 
 Installation
 ------------


### PR DESCRIPTION
**New users** are unsure whether or not this Bundle functions correctly with Symfony3. Also, as **existing users** migrate from symfony2.x to symfony3.x, its important for them to know if the bundle is functional with their symfony installation.