### PR TITLE
Automatically register the PhoneNumberType DBAL type

### DIFF
--- a/DependencyInjection/MisdPhoneNumberExtension.php
+++ b/DependencyInjection/MisdPhoneNumberExtension.php
@@ -14,6 +14,7 @@ namespace Misd\PhoneNumberBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
@@ -21,7 +22,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 /**
  * Bundle extension.
  */
-class MisdPhoneNumberExtension extends Extension
+class MisdPhoneNumberExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * {@inheritdoc}
@@ -36,6 +37,23 @@ class MisdPhoneNumberExtension extends Extension
         $this->setFactory($container->getDefinition('libphonenumber.short_number_info'));
         $this->setFactory($container->getDefinition('libphonenumber.phone_number_to_carrier_mapper'));
         $this->setFactory($container->getDefinition('libphonenumber.phone_number_to_time_zones_mapper'));
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        $container->prependExtensionConfig('doctrine', array(
+            'dbal' => array(
+                'types' => array(
+                    'phone_number' => array(
+                        'class' => 'Misd\PhoneNumberBundle\Doctrine\DBAL\Types\PhoneNumberType',
+                        'commented' => false
+                    )
+                )
+            )
+        ));
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -51,14 +51,7 @@ So to parse a string into a `libphonenumber\PhoneNumber` object:
 
 *Requires `doctrine/doctrine-bundle`.*
 
-To persist `libphonenumber\PhoneNumber` objects, add the `Misd\PhoneNumberBundle\Doctrine\DBAL\Types\PhoneNumberType` mapping to your application's config:
-
-    // app/config.yml
-
-    doctrine:
-        dbal:
-            types:
-                phone_number: Misd\PhoneNumberBundle\Doctrine\DBAL\Types\PhoneNumberType
+To be able to persist `libphonenumber\PhoneNumber` objects, the `Misd\PhoneNumberBundle\Doctrine\DBAL\Types\PhoneNumberType` custom DBAL type is automatically registered in your application config under the `phone_number` key.
 
 You can then use the `phone_number` mapping:
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.3.3",
         "giggsey/libphonenumber-for-php": "~5.7|~6.0|~7.0|~8.0",
-        "symfony/framework-bundle": "~2.1|~3.0"
+        "symfony/framework-bundle": "~2.3|~3.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "~1.0",


### PR DESCRIPTION
Fixed ticket : https://github.com/misd-service-development/phone-number-bundle/issues/136

I had to require a higher version of the `symfony/framework-bundle` to get at least `symfony/dependency-injection` at version 2.2 because the `PrependExtensionInterface` interface only exists at this location since this version.

Also I set the `commented` option to `false` in the config because of a problem I discovered yesterday and that is related to the DoctrineBundle (cf https://github.com/doctrine/DoctrineBundle/issues/670). Basically keeping `commtented` to `true` (which is the default value) prevents the user from using the `doctrine:database:create` command. We don't really have to specify that the type is commented since the method `requiresSQLCommentHint` in the type class returns true.