### PR TITLE
Display preferred choices in the order they are provided with

### DIFF
--- a/Form/Type/PhoneNumberType.php
+++ b/Form/Type/PhoneNumberType.php
@@ -101,6 +101,10 @@ class PhoneNumberType extends AbstractType
                 $countryOptions['placeholder'] = $options['country_placeholder'];
             }
 
+            if (!empty($countryOptions['preferred_choices'])) {
+                $this->applyPreferredSorting($countryOptions);
+            }
+
             $builder
                 ->add('country', $choiceType, $countryOptions)
                 ->add('number', $textType, $numberOptions)
@@ -110,6 +114,16 @@ class PhoneNumberType extends AbstractType
                 new PhoneNumberToStringTransformer($options['default_region'], $options['format'])
             );
         }
+    }
+
+    private function applyPreferredSorting(&$countryOptions)
+    {
+        $choices = array_flip($countryOptions['choices']);
+        $preferredChoices = array_flip($countryOptions['preferred_choices']);
+        foreach ($preferredChoices as $key => &$value) {
+            $value = $choices[$key];
+        }
+        $countryOptions['choices'] = array_flip($preferredChoices) + $countryOptions['choices'];
     }
 
     /**


### PR DESCRIPTION
Hello.

This fixes an issue with symfony's preferred choices sorting always being alphabetical.
https://github.com/symfony/symfony/issues/5136 (2012 and still opened).