### PR TITLE
Use trusty for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 sudo: false
 
 language: php

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -20,7 +19,8 @@ cache:
 matrix:
     fast_failure: true
     include:
-        - php: 5.3
+        - dist: precise
+          php: 5.3
           env: dependencies=lowest
         - php: 7.0
           env: SYMFONY_VERSION=2.3.x


### PR DESCRIPTION
HHVM is no longer supported on Ubuntu Precise (12.04) so upgrade to Trusty (14.04)