### PR TITLE
Fix autowiring deprecation

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -22,14 +22,19 @@
     <services>
 
         <service id="libphonenumber.phone_number_util" class="libphonenumber\PhoneNumberUtil"/>
+        <service id="libphonenumber\PhoneNumberUtil" alias="libphonenumber.phone_number_util"/>
 
         <service id="libphonenumber.phone_number_offline_geocoder" class="libphonenumber\geocoding\PhoneNumberOfflineGeocoder"/>
+        <service id="libphonenumber\geocoding\PhoneNumberOfflineGeocoder" alias="libphonenumber.phone_number_offline_geocoder"/>
 
         <service id="libphonenumber.short_number_info" class="libphonenumber\ShortNumberInfo"/>
+        <service id="libphonenumber\ShortNumberInfo" alias="libphonenumber.short_number_info"/>
 
         <service id="libphonenumber.phone_number_to_carrier_mapper" class="libphonenumber\PhoneNumberToCarrierMapper"/>
+        <service id="libphonenumber\PhoneNumberToCarrierMapper" alias="libphonenumber.phone_number_to_carrier_mapper"/>
 
         <service id="libphonenumber.phone_number_to_time_zones_mapper" class="libphonenumber\PhoneNumberToTimeZonesMapper"/>
+        <service id="libphonenumber\PhoneNumberToTimeZonesMapper" alias="libphonenumber.phone_number_to_time_zones_mapper"/>
 
         <service id="misd_phone_number.templating.helper"
                  class="Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper">
@@ -37,18 +42,20 @@
             <!-- phone_number_format is deprecated and will be removed in 2.0 (use phone_number_helper instead) -->
             <tag name="templating.helper" alias="phone_number_format"/>
             <argument type="service" id="libphonenumber.phone_number_util"/>
-
         </service>
+        <service id="Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper" alias="misd_phone_number.templating.helper"/>
 
         <service id="misd_phone_number.twig.extension.format" class="Misd\PhoneNumberBundle\Twig\Extension\PhoneNumberHelperExtension"
                  public="false">
             <tag name="twig.extension"/>
             <argument type="service" id="misd_phone_number.templating.helper"/>
         </service>
+        <service id="Misd\PhoneNumberBundle\Twig\Extension\PhoneNumberHelperExtension" alias="misd_phone_number.twig.extension.format"/>
 
         <service id="misd_phone_number.form.type" class="Misd\PhoneNumberBundle\Form\Type\PhoneNumberType">
             <tag name="form.type" alias="tel"/>
         </service>
+        <service id="Misd\PhoneNumberBundle\Form\Type\PhoneNumberType" alias="misd_phone_number.form.type"/>
 
         <service id="misd_phone_number.serializer.handler" class="Misd\PhoneNumberBundle\Serializer\Handler\PhoneNumberHandler">
             <tag name="jms_serializer.handler" type="libphonenumber\PhoneNumber" direction="serialization"
@@ -63,12 +70,13 @@
                  format="yml" method="serializePhoneNumber"/>
             <argument type="service" id="libphonenumber.phone_number_util"/>
         </service>
+        <service id="Misd\PhoneNumberBundle\Serializer\Handler\PhoneNumberHandler" alias="misd_phone_number.serializer.handler"/>
 
         <service id="misd_phone_number.serializer.normalizer" class="Misd\PhoneNumberBundle\Serializer\Normalizer\PhoneNumberNormalizer">
             <tag name="serializer.normalizer" />
-
             <argument type="service" id="libphonenumber.phone_number_util" />
         </service>
+        <service id="Misd\PhoneNumberBundle\Serializer\Normalizer\PhoneNumberNormalizer" alias="misd_phone_number.serializer.normalizer"/>
     </services>
 
 </container>


### PR DESCRIPTION
Fix for `Autowiring services based on the types they implement is deprecated since Symfony 3.3 and won't be supported in version 4.0. You should rename (or alias) the "libphonenumber.phone_number_util" service to "libphonenumber\PhoneNumberUtil" instead.` deprecation when trying to autowire services.