### PR TITLE
Support `default_region` for `PhoneNumberType` with option `'widget' => PhoneNumberType::WIDGET_COUNTRY_CHOICE`

### DIFF
--- a/Form/Type/PhoneNumberType.php
+++ b/Form/Type/PhoneNumberType.php
@@ -97,6 +97,10 @@ class PhoneNumberType extends AbstractType
             $countryOptions['choices'] = $countryChoices;
             $countryOptions['preferred_choices'] = $options['preferred_country_choices'];
 
+            if ($options['default_region'] !== PhoneNumberUtil::UNKNOWN_REGION) {
+                $countryOptions['data'] = $options['default_region'];
+            }
+
             if ($options['country_placeholder']) {
                 $countryOptions['placeholder'] = $options['country_placeholder'];
             }


### PR DESCRIPTION
Solves https://github.com/misd-service-development/phone-number-bundle/issues/189