### PR TITLE
placeholder for number

### DIFF
--- a/Form/Type/PhoneNumberType.php
+++ b/Form/Type/PhoneNumberType.php
@@ -101,6 +101,10 @@ class PhoneNumberType extends AbstractType
                 $countryOptions['placeholder'] = $options['country_placeholder'];
             }
 
+            if ($options['number_placeholder']) {
+                $numberOptions['attr'] = ['placeholder' => $options['number_placeholder']];
+            }
+
             $builder
                 ->add('country', $choiceType, $countryOptions)
                 ->add('number', $textType, $numberOptions)
@@ -150,6 +154,7 @@ class PhoneNumberType extends AbstractType
                 'error_bubbling' => false,
                 'country_choices' => array(),
                 'country_placeholder' => false,
+                'number_placeholder' => false,
                 'preferred_country_choices' => array(),
             )
         );
@@ -188,6 +193,6 @@ class PhoneNumberType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'phone_number';
+        return 'tel';
     }
 }


### PR DESCRIPTION
Add "number_placeholder" option for `PhoneNumberType::WIDGET_COUNTRY_CHOICE`

Can be used like this
```
            ->add('primaryContactPhone', PhoneNumberType::class, [
                'widget' => PhoneNumberType::WIDGET_COUNTRY_CHOICE,
                'country_choices' => $this->countryRepository->getCodes(),
                'preferred_country_choices' => [$options['countryCode']],
                'number_placeholder' => $this->phoneNumberUtil->getExampleNumber($options['countryCode'])->getNationalNumber(),
            ])
```
provides a selected country with an example number.