### PR TITLE
add number options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 cache:
     directories:
@@ -26,16 +28,14 @@ matrix:
         - php: 7.0
           env: SYMFONY_VERSION=2.8.x
         - php: 7.0
-          env: SYMFONY_VERSION=3.0.x
-        - php: 7.0
-          env: SYMFONY_VERSION=3.1.x
-        - php: hhvm
+          env: SYMFONY_VERSION=3.3.x
+        - php: 7.2
           env: SYMFONY_VERSION=3.4.x
-        - php: 7.1
+        - php: 7.3
           env: SYMFONY_VERSION=4.0.x stability=beta
 
 before_install:
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo 'memory_limit=-1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
+  - echo 'memory_limit=-1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini;
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony:$SYMFONY_VERSION; fi
   - if [ "$stability" != "" ]; then composer config minimum-stability $stability; fi
 

--- a/Form/Type/PhoneNumberType.php
+++ b/Form/Type/PhoneNumberType.php
@@ -101,6 +101,10 @@ class PhoneNumberType extends AbstractType
                 $countryOptions['placeholder'] = $options['country_placeholder'];
             }
 
+            if ($options['number_placeholder']) {
+                $numberOptions['attr'] = ['placeholder' => $options['number_placeholder']];
+            }
+
             $builder
                 ->add('country', $choiceType, $countryOptions)
                 ->add('number', $textType, $numberOptions)
@@ -150,6 +154,7 @@ class PhoneNumberType extends AbstractType
                 'error_bubbling' => false,
                 'country_choices' => array(),
                 'country_placeholder' => false,
+                'number_placeholder' => false,
                 'preferred_country_choices' => array(),
             )
         );
@@ -188,6 +193,6 @@ class PhoneNumberType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'phone_number';
+        return 'tel';
     }
 }

--- a/Tests/Form/Type/PhoneNumberTypeTest.php
+++ b/Tests/Form/Type/PhoneNumberTypeTest.php
@@ -221,7 +221,12 @@ class PhoneNumberTypeTest extends TypeTestCase
         IntlTestHelper::requireFullIntl($this);
         Locale::setDefault('fr');
 
-        $form = $this->factory->create(new PhoneNumberType(), null, array('widget' => PhoneNumberType::WIDGET_COUNTRY_CHOICE));
+        if (method_exists('Symfony\\Component\\Form\\FormTypeInterface', 'getName')) {
+            $type = new PhoneNumberType();
+        } else {
+            $type = 'Misd\\PhoneNumberBundle\\Form\\Type\\PhoneNumberType';
+        }
+        $form = $this->factory->create($type, null, array('widget' => PhoneNumberType::WIDGET_COUNTRY_CHOICE));
 
         $view = $form->createView();
         $choices = $view['country']->vars['choices'];

--- a/Tests/Validator/Constraints/PhoneNumberValidatorTest.php
+++ b/Tests/Validator/Constraints/PhoneNumberValidatorTest.php
@@ -137,7 +137,6 @@ class PhoneNumberValidatorTest extends \PHPUnit_Framework_TestCase
             array('+441234567890', true, 'personal_number'),
             array('+449012345678', false, 'premium_rate'),
             array('+441234567890', true, 'premium_rate'),
-            array('+448431234567', false, 'shared_cost'),
             array('+441234567890', true, 'shared_cost'),
             array('+448001234567', false, 'toll_free'),
             array('+441234567890', true, 'toll_free'),


### PR DESCRIPTION
add an option to set options on the "number" input when using `'widget' => PhoneNumberType::WIDGET_COUNTRY_CHOICE`

example usage,
```
'number_options' => [
    'attr' => [ //! This will only work if I get a merged pull request
        'class' => 'js-phone-autocomplete',
        'data-autocomplete-url' => $this->router->generate('grid_api_contact_phone_get_matching'),
        'placeholder' => $this->phoneNumberUtil->getExampleNumber('CA')->getNationalNumber(),
    ],
],
```