### PR TITLE
add number options option

### DIFF
--- a/Form/Type/PhoneNumberType.php
+++ b/Form/Type/PhoneNumberType.php
@@ -101,6 +101,10 @@ class PhoneNumberType extends AbstractType
                 $countryOptions['placeholder'] = $options['country_placeholder'];
             }
 
+            if ($options['number_options']) {
+                $numberOptions = $numberOptions + $options['number_options'];
+            }
+
             $builder
                 ->add('country', $choiceType, $countryOptions)
                 ->add('number', $textType, $numberOptions)
@@ -150,6 +154,7 @@ class PhoneNumberType extends AbstractType
                 'error_bubbling' => false,
                 'country_choices' => array(),
                 'country_placeholder' => false,
+                'number_options' => false,
                 'preferred_country_choices' => array(),
             )
         );


### PR DESCRIPTION
pass options to the number input when using `PhoneNumberType::WIDGET_COUNTRY_CHOICE`  
use like,
```
$builder->add('primaryContactPhone', PhoneNumberType::class, [
    'widget' => PhoneNumberType::WIDGET_COUNTRY_CHOICE,
    'country_choices' => $this->countryRepository->getCodes(),
    'preferred_country_choices' => [$options['countryCodes']],
    'number_options' => [
        'attr' => [
            'class' => 'js-phone-autocomplete',
            'data-autocomplete-url' => $this->router->generate('grid_api_contact_phone_get_matching'),
            'placeholder' => $this->phoneNumberUtil->getExampleNumber($options['countryCodes'])->getNationalNumber(),
        ],
    ],
])
```